### PR TITLE
Add Render deployment config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: spot-ai-agent
+    env: python
+    plan: free
+    buildCommand: |
+      pip install --upgrade pip setuptools wheel
+      pip install -r requirements.txt
+    startCommand: python agent.py
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.10.13


### PR DESCRIPTION
## Summary
- create `render.yaml` to configure service with `pip install --upgrade pip setuptools wheel` and `pip install -r requirements.txt`
- specify Python 3.10.13 via env var

## Testing
- `python agent.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68780bbd4f88832e86d779987244cca4