### PR TITLE
Fix python-dotenv dependency for Render

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,10 @@ setuptools>=65.5.0
 Cython>=0.29.36
 python-binance==1.0.17
 ta==0.10.2
-python-dotenv
+python-dotenv>=1.0.0
 requests
 ccxt
 yfinance
 streamlit
 openai
-python-dotenv>=0.21.0
 


### PR DESCRIPTION
## Summary
- ensure `python-dotenv` is installed by pinning a recent version

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68781090df08832e900c59a42bfb0b78