### PR TITLE
Fix trade history parsing & index

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -219,12 +219,28 @@ if not hist_df.empty:
     if "size" not in hist_df.columns and "position_size" in hist_df.columns:
         hist_df["size"] = hist_df["position_size"].astype(float)
     # Compute PnL absolute and percent
-    directions = hist_df.get("direction", "long").astype(str)
-    entries = pd.to_numeric(hist_df.get("entry", 0), errors="coerce")
-    exits = pd.to_numeric(hist_df.get("exit", hist_df.get("exit_price", np.nan)), errors="coerce")
-    sizes = pd.to_numeric(hist_df.get("size", 1), errors="coerce").fillna(1)
-    fees = pd.to_numeric(hist_df.get("fees", 0), errors="coerce").fillna(0)
-    slippage = pd.to_numeric(hist_df.get("slippage", 0), errors="coerce").fillna(0)
+    if "direction" in hist_df.columns:
+        directions = hist_df["direction"].astype(str)
+    else:
+        directions = pd.Series(["long"] * len(hist_df))
+
+    if "entry" in hist_df.columns:
+        entries = pd.to_numeric(hist_df["entry"], errors="coerce")
+    else:
+        entries = pd.Series([0] * len(hist_df), dtype=float)
+
+    if "exit" in hist_df.columns:
+        exits = pd.to_numeric(hist_df["exit"], errors="coerce")
+    else:
+        exits = pd.to_numeric(hist_df.get("exit_price", pd.Series([np.nan] * len(hist_df))), errors="coerce")
+
+    if "size" in hist_df.columns:
+        sizes = pd.to_numeric(hist_df["size"], errors="coerce").fillna(1)
+    else:
+        sizes = pd.Series([1] * len(hist_df), dtype=float)
+
+    fees = pd.to_numeric(hist_df.get("fees", pd.Series([0] * len(hist_df))), errors="coerce").fillna(0)
+    slippage = pd.to_numeric(hist_df.get("slippage", pd.Series([0] * len(hist_df))), errors="coerce").fillna(0)
     # Determine direction multiplier
     direction_sign = np.where(directions.str.lower().str.startswith("s"), -1, 1)
     pnl_abs = (exits - entries) * sizes * direction_sign

--- a/trade_utils.py
+++ b/trade_utils.py
@@ -368,14 +368,31 @@ def get_price_data(symbol: str) -> Optional[pd.DataFrame]:
     try:
         mapped_symbol = map_symbol_for_binance(symbol)
         klines = client.get_klines(symbol=mapped_symbol, interval=Client.KLINE_INTERVAL_5MINUTE, limit=500)
-        df = pd.DataFrame(klines, columns=[
-            'timestamp', 'open', 'high', 'low', 'close', 'volume',
-            'close_time', 'quote_asset_volume', 'number_of_trades',
-            'taker_buy_base', 'taker_buy_quote', 'ignore'
-        ])
-        df[['open', 'high', 'low', 'close', 'volume', 'quote_asset_volume']] = df[['open', 'high', 'low', 'close', 'volume', 'quote_asset_volume']].astype(float)
-        df['quote_volume'] = df['quote_asset_volume']
-        return df[['open', 'high', 'low', 'close', 'volume', 'quote_volume']]
+        df = pd.DataFrame(
+            klines,
+            columns=[
+                "timestamp",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "close_time",
+                "quote_asset_volume",
+                "number_of_trades",
+                "taker_buy_base",
+                "taker_buy_quote",
+                "ignore",
+            ],
+        )
+        df[["open", "high", "low", "close", "volume", "quote_asset_volume"]] = df[
+            ["open", "high", "low", "close", "volume", "quote_asset_volume"]
+        ].astype(float)
+        # Convert timestamp column to datetime and set as index for time series operations
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms", errors="coerce")
+        df = df.set_index("timestamp")
+        df["quote_volume"] = df["quote_asset_volume"]
+        return df[["open", "high", "low", "close", "volume", "quote_volume"]]
     except Exception as e:
         print(f"⚠️ Failed to fetch data for {symbol}: {e}")
         return None


### PR DESCRIPTION
## Summary
- parse historical trades defensively
- convert fetched price timestamps to datetime index

## Testing
- `python -m py_compile dashboard.py trade_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68880137bf5c832e9949eaeeaa245a7f