### PR TITLE
Fix start command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,4 +4,4 @@ services:
     env: python
     pythonVersion: 3.10.13
     buildCommand: pip install -r requirements.txt
-    startCommand: python agent.py
+    startCommand: python3 agent.py


### PR DESCRIPTION
## Summary
- fix start command in `render.yaml`

## Testing
- `python3 agent.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_688941986648832e9774eeff7feafb02