### PR TITLE
Improve warnings for missing Binance client

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -138,6 +138,11 @@ def run_agent_loop():
             save_active_trades(active_trades)
             # Get top symbols to scan
             top_symbols = get_top_symbols(limit=30)
+            if not top_symbols:
+                print(
+                    "\u26A0\uFE0F No symbols fetched from Binance. Check your "
+                    "python-binance installation and network connectivity."
+                )
             session = get_market_session()
             potential_trades = []
             symbol_scores = {}

--- a/trade_utils.py
+++ b/trade_utils.py
@@ -339,7 +339,12 @@ SYMBOL_SCORES_FILE = os.path.join(os.path.dirname(__file__), "symbol_scores.json
 # Initialise Binance client if available
 try:
     client = Client()
-except Exception:
+except Exception as e:
+    print(
+        f"\u26A0\uFE0F Failed to initialize Binance client: {e}.\n"
+        "   Install the 'python-binance' package and ensure network/credentials"
+        " are configured."
+    )
     client = None
 
 


### PR DESCRIPTION
## Summary
- warn when failing to initialize the Binance client
- notify when no symbols are fetched during scans

## Testing
- `python3 -m py_compile agent.py trade_utils.py && echo "py_compile success"`

------
https://chatgpt.com/codex/tasks/task_e_688943bdecc4832eaf608dced8db34fb