### PR TITLE
Centralize trade storage and add DB-backed dashboard

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,12 @@ services:
         fromDatabase:
           name: spot-ai-db
           property: connectionString
+      - key: DATA_DIR
+        value: /var/data
+    disks:
+      - name: trade-data
+        mountPath: /var/data
+        sizeGB: 1
 databases:
   - name: spot-ai-db
     plan: free


### PR DESCRIPTION
## Summary
- Route active trade persistence through `trade_storage` for unified JSON/DB handling
- Update agent and dashboard to use shared storage layer and load history from PostgreSQL when available
- Mount persistent data volume via Render configuration

## Testing
- `python -m py_compile trade_storage.py trade_manager.py agent.py dashboard.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a705c0bd0832dbb8843d540cbd352