### PR TITLE
Improve async scanning and backtest analytics

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -246,10 +246,15 @@ def run_agent_loop() -> None:
             if symbols_to_fetch:
                 async def fetch_batch(symbols):
                     tasks = [get_price_data_async(s) for s in symbols]
-                    return await asyncio.gather(*tasks)
+                    return await asyncio.gather(*tasks, return_exceptions=True)
 
                 price_results = asyncio.run(fetch_batch(symbols_to_fetch))
-                price_map = dict(zip(symbols_to_fetch, price_results))
+                price_map = {}
+                for sym, res in zip(symbols_to_fetch, price_results):
+                    if isinstance(res, Exception):
+                        logger.error("Error fetching %s: %s", sym, res, exc_info=True)
+                    else:
+                        price_map[sym] = res
             else:
                 price_map = {}
             for symbol in symbols_to_fetch:

--- a/dashboard.py
+++ b/dashboard.py
@@ -286,6 +286,10 @@ def render_backtest_tab():
             st.line_chart(df["equity"], use_container_width=True)
         if "pnl" in df.columns:
             st.bar_chart(df["pnl"], use_container_width=True)
+            # Display distribution of returns as a histogram
+            hist, bins = np.histogram(df["pnl"].astype(float), bins=20)
+            hist_df = pd.DataFrame({"Return": bins[:-1], "Count": hist})
+            st.bar_chart(hist_df.set_index("Return"), use_container_width=True)
         st.dataframe(df, use_container_width=True)
 
 


### PR DESCRIPTION
## Summary
- Handle price data requests concurrently with detailed error logging for failures
- Enhance Streamlit backtest tab with return distribution histogram for uploaded logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d1b91beec832db15d72460fe06e3a