### PR TITLE
Add gunicorn dependency and health checks

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,7 @@ services:
     pythonVersion: 3.10.13
     buildCommand: pip install -r requirements.txt
     startCommand: python3 agent.py
+    healthCheckPath: /
     envVars:
       - key: RUN_DASHBOARD
         value: "0"
@@ -24,6 +25,7 @@ services:
     pythonVersion: 3.10.13
     buildCommand: pip install -r requirements.txt
     startCommand: streamlit run dashboard.py --server.port $PORT --server.headless true
+    healthCheckPath: /
     envVars:
       - key: DATA_DIR
         value: /var/data

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ beautifulsoup4
 psycopg2-binary
 aiohttp
 pytest
+gunicorn


### PR DESCRIPTION
## Summary
- Add gunicorn to requirements to ensure web server is available
- Define health check paths for web services in render configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dd94524f0832db23c1328fd1081fe