### PR TITLE
Enhance ML models with boosted trees and sequence forecast

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -47,6 +47,7 @@ from fear_greed import get_fear_greed_index
 from orderflow import detect_aggression
 from diversify import select_diversified_signals
 from ml_model import predict_success_probability
+from sequence_model import predict_next_return
 from drawdown_guard import is_trading_blocked
 import numpy as np
 
@@ -349,6 +350,12 @@ def run_agent_loop() -> None:
                     }
                 except Exception:
                     indicators = {"rsi": 50.0, "macd": 0.0, "adx": 20.0}
+                next_ret = 0.0
+                try:
+                    next_ret = predict_next_return(price_data.tail(10))
+                except Exception:
+                    pass
+                indicators['next_return'] = next_ret
                 # Ask the brain whether to take the trade
                 # Call the brain with error handling.  If the brain throws an
                 # exception, record it as the reason for skipping so users

--- a/brain.py
+++ b/brain.py
@@ -270,6 +270,14 @@ def should_trade(
             ):
                 confidence += 0.8
 
+        exp_ret = indicators.get('next_return')
+        if exp_ret is not None:
+            try:
+                adj = max(min(float(exp_ret) * 50.0, 2.0), -2.0)
+                confidence += adj
+            except Exception:
+                pass
+
         # Clamp confidence into [0, 10]
         final_confidence = round(max(0.0, min(confidence, 10.0)), 2)
 


### PR DESCRIPTION
## Summary
- add optional XGBoost and LightGBM classifiers to success-probability training with expanded hyperparameter grids
- broaden sequence model with boosted regressors and cross-validated model selection
- feed sequence model’s predicted return into agent indicators and confidence adjustments

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0a020de14832d86cc94116ffa82a9