### PR TITLE
Add systemd service units and document persistent storage paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,32 @@ pip install -r requirements.txt
 Set the following environment variables as needed:
 
 - `BINANCE_API_KEY` / `BINANCE_API_SECRET`
-- `DATA_DIR` – directory for persistent trade logs
+- `DATA_DIR` – optional override for trade storage. Defaults to
+  `/home/ubuntu/spot_data/trades`.
 - `RUN_DASHBOARD` – set to `1` to launch the Streamlit dashboard from the agent
+
+### Persistent data
+
+All runtime data is written to real directories under
+`/home/ubuntu/spot_data` so nothing relies on writable symlinks.  The key
+files are:
+
+```
+/home/ubuntu/spot_data/logs/spot_ai.log          # agent log output
+/home/ubuntu/spot_data/trades/active_trades.json # open positions
+/home/ubuntu/spot_data/trades/completed_trades.csv
+/home/ubuntu/spot_data/trades/rejected_trades.csv
+/home/ubuntu/spot_data/trades/trade_logs.csv
+```
+
+Symlinks back into the repository are created only for read-only
+compatibility with existing tools, but all writes happen directly in the
+`spot_data` tree.
+
+Systemd unit files for the agent and dashboard are provided in the
+`systemd/` directory.  Both services explicitly grant write access to
+`/home/ubuntu/spot_data` via `ReadWritePaths` so historical trade data
+persists across restarts.
 
 ## Running
 

--- a/systemd/spot-agent.service
+++ b/systemd/spot-agent.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Spot AI trading agent
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/Spot-Ai-Agent
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/usr/bin/python3 /home/ubuntu/Spot-Ai-Agent/agent.py
+Restart=on-failure
+ReadWritePaths=/home/ubuntu/spot_data /home/ubuntu/spot_data/logs /home/ubuntu/spot_data/trades
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/spot-dashboard.service
+++ b/systemd/spot-dashboard.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Spot AI dashboard
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/Spot-Ai-Agent
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/usr/bin/python3 -m streamlit run /home/ubuntu/Spot-Ai-Agent/dashboard.py --server.port 8501 --server.headless true
+Restart=on-failure
+ReadWritePaths=/home/ubuntu/spot_data /home/ubuntu/spot_data/logs /home/ubuntu/spot_data/trades
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- document that logs and trade data live under `/home/ubuntu/spot_data` and add section describing persistent storage
- add systemd unit files for spot-agent and spot-dashboard with `ReadWritePaths` to `/home/ubuntu/spot_data`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6d3c603a8832d8104db9b3710a25c