### PR TITLE
feat: dynamic max trades based on market conditions

### DIFF
--- a/tests/test_dynamic_trades.py
+++ b/tests/test_dynamic_trades.py
@@ -1,0 +1,11 @@
+from agent import dynamic_max_active_trades, MAX_ACTIVE_TRADES
+
+def test_reduces_trades_in_fear():
+    assert dynamic_max_active_trades(10, "neutral", 0.5) == 1
+
+def test_increases_trades_when_bullish_low_vol():
+    assert dynamic_max_active_trades(80, "bullish", 0.2) == MAX_ACTIVE_TRADES + 1
+
+def test_high_volatility_cuts_allocation():
+    assert dynamic_max_active_trades(80, "bullish", 0.9) == MAX_ACTIVE_TRADES
+


### PR DESCRIPTION
## Summary
- adapt max concurrent trades using fear & greed, sentiment and BTC volatility
- test dynamic trade allocation logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7917e7f58832d80ce05ad862197c5