### PR TITLE
Fix RL action update and macro sentiment exit threshold

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -519,6 +519,8 @@ def run_agent_loop() -> None:
                             "tp3": tp3,
                             "position_size": position_size,
                             "size": position_size,  # duplicate for dashboard convenience
+                            "rl_state": state,
+                            "rl_multiplier": mult,
                             "leverage": 1,  # default leverage (spot)
                             "confidence": final_conf,
                             "score": score,


### PR DESCRIPTION
## Summary
- track RL state and multiplier for each trade so Q-learning updates the action actually taken
- raise macro sentiment exit threshold to require high-confidence bearish signals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a793af2020832da22ea185d68886d6