### PR TITLE
Use shared trade log path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ files are:
 ```
 /home/ubuntu/spot_data/logs/spot_ai.log          # agent log output
 /home/ubuntu/spot_data/trades/active_trades.json # open positions
-/home/ubuntu/spot_data/trades/completed_trades.csv
+/home/ubuntu/spot_data/trades/completed_trades.csv # unified trade log
 /home/ubuntu/spot_data/trades/rejected_trades.csv
-/home/ubuntu/spot_data/trades/trade_logs.csv
 ```
 
 Symlinks back into the repository are created only for read-only

--- a/confidence.py
+++ b/confidence.py
@@ -2,7 +2,8 @@
 Historical confidence calculator for trade outcomes.
 
 This module provides a function to compute a confidence estimate for a
-potential trade based on past performance recorded in ``trade_learning_log.csv``.
+potential trade based on past performance recorded in the completed
+trades log (``COMPLETED_TRADES_FILE``).
 It reads the log with tolerant parsing (skipping bad lines) and filters
 similar trades by symbol, direction, score range and session.  The
 confidence is scaled between 0 and 100 and includes a small boost if
@@ -12,11 +13,10 @@ recent trades show better performance.
 import pandas as pd
 import os
 
-import os
+from trade_storage import COMPLETED_TRADES_FILE
 
-# Path to the learning log CSV.  Use a fixed path relative to this module
-# so it is consistent regardless of the current working directory.
-LOG_FILE = os.path.join(os.path.dirname(__file__), "trade_learning_log.csv")
+# Path to the completed trades log for historical confidence calculations
+LOG_FILE = COMPLETED_TRADES_FILE
 
 
 def calculate_historical_confidence(symbol, score, direction, session="Unknown", pattern_name=None):

--- a/confidence_guard.py
+++ b/confidence_guard.py
@@ -1,8 +1,8 @@
 """
 Adaptive confidence threshold guard based on recent trade outcomes.
 
-This module reads ``trade_learning_log.csv`` to compute a dynamic confidence
-threshold that adapts to your strategy's performance.  If the log file is
+This module reads the unified completed trades log to compute a dynamic
+confidence threshold that adapts to your strategy's performance.  If the log file is
 missing, contains too few entries, or has malformed lines, a conservative
 default threshold is returned.  You can use the returned value in your
 brain/decision logic to calibrate how strict the bot should be.
@@ -11,18 +11,17 @@ brain/decision logic to calibrate how strict the bot should be.
 import pandas as pd
 import os
 
-import os
+from trade_storage import COMPLETED_TRADES_FILE
 
-# Path to the learning log CSV.  Use a fixed path relative to this module
-# so it is consistent regardless of the current working directory.
-LEARNING_LOG = os.path.join(os.path.dirname(__file__), "trade_learning_log.csv")
+# Path to the completed trades log used for adaptive thresholding
+LEARNING_LOG = COMPLETED_TRADES_FILE
 
 
 def get_adaptive_conf_threshold() -> float:
     """
     Calculate an adaptive confidence threshold based on recent performance.
 
-    The function reads the last 25 entries of ``trade_learning_log.csv`` and
+    The function reads the last 25 entries of the completed trades log and
     computes the win rate and average confidence.  If the win rate is
     exceptionally high (>=70%), the threshold is lowered slightly; if the
     win rate is low (<=40%), the threshold is raised slightly.  Otherwise,

--- a/memory_retriever.py
+++ b/memory_retriever.py
@@ -2,7 +2,7 @@
 Utilities for retrieving past trade memories.
 
 This module provides helper functions to summarise recent trades from the
-trade learning log.  The summary can be used to give the LLM context
+completed trades log (``COMPLETED_TRADES_FILE``).  The summary can be used to give the LLM context
 about similar past trades, enabling it to reason based on prior
 experience (retrieval‑augmented generation).
 """
@@ -13,9 +13,10 @@ import os
 from typing import Optional
 
 import pandas as pd
+from trade_storage import COMPLETED_TRADES_FILE
 
-# Path to the learning log file (same directory as this module)
-LOG_FILE = os.path.join(os.path.dirname(__file__), "trade_learning_log.csv")
+# Path to the completed trades log used for memory retrieval
+LOG_FILE = COMPLETED_TRADES_FILE
 
 
 def get_recent_trade_summary(symbol: str, pattern: str, max_entries: int = 3) -> str:

--- a/ml_model.py
+++ b/ml_model.py
@@ -44,6 +44,7 @@ from typing import List, Tuple, Dict, Any, Optional
 import numpy as np
 import pandas as pd
 from log_utils import setup_logger
+from trade_storage import COMPLETED_TRADES_FILE
 
 try:
     # Core sklearn components used for modelling and preprocessing
@@ -88,7 +89,7 @@ logger = setup_logger(__name__)
 # ---------------------------------------------------------------------------
 
 ROOT_DIR = os.path.dirname(__file__)
-LOG_FILE = os.path.join(ROOT_DIR, "trade_learning_log.csv")
+LOG_FILE = COMPLETED_TRADES_FILE
 MODEL_JSON = os.path.join(ROOT_DIR, "ml_model.json")
 MODEL_PKL = os.path.join(ROOT_DIR, "ml_model.pkl")
 
@@ -165,7 +166,8 @@ def train_model(iterations: int = 200, learning_rate: float = 0.1) -> None:
     Train and select the best classification model on the trade learning log.
 
     If scikit‑learn is available, this function performs the following:
-    1. Extracts features and labels from ``trade_learning_log.csv``.
+    1. Extracts features and labels from the completed trades log
+       (``COMPLETED_TRADES_FILE``).
     2. Scales the features using ``StandardScaler``.
     3. Defines a grid of candidate models (logistic regression,
        random forest and gradient boosting) along with hyper‑parameter

--- a/trade_logger.py
+++ b/trade_logger.py
@@ -1,98 +1,40 @@
 """
-Logger for final trade outcomes (updated).
+Logger for final trade outcomes (deprecated).
 
-This module defines ``log_trade_result`` which appends a record to
-``trade_learning_log.csv`` whenever a trade closes.  The log captures key
-information such as the symbol, session, trade score, direction, outcome,
-macro context (including sentiment bias) and final confidence.  The CSV is appended with headers if
-absent.  Caller should ensure that each trade dict contains the expected
-keys (see below).  If optional fields are missing, sensible defaults are
-used.
-
-Unlike the original version, this update allows overriding the path of
-the learning log via the ``TRADE_LEARNING_LOG_FILE`` environment
-variable and resolves the default path relative to this module.  This
-ensures consistent file locations across different processes.
+This module now delegates trade result logging to ``trade_storage``.
+``log_trade_result`` is provided only for backward compatibility and will
+emit a ``DeprecationWarning`` when used.  All paths resolve to the unified
+completed trades log managed by ``trade_storage``.
 """
 
-import csv
 import os
-from datetime import datetime
+import warnings
 from log_utils import ensure_symlink
-
-
-TRADE_LEARNING_LOG_FILE = os.environ.get(
-    "TRADE_LEARNING_LOG_FILE", "/home/ubuntu/spot_data/trades/trade_logs.csv"
+from trade_storage import (
+    COMPLETED_TRADES_FILE,
+    log_trade_result as _storage_log_trade_result,
 )
-TRADE_LOG_FILE = os.environ.get("TRADE_LOG_FILE", TRADE_LEARNING_LOG_FILE)
 
 
-def log_trade_result(trade: dict, outcome: str, **kwargs) -> None:
+TRADE_LEARNING_LOG_FILE = COMPLETED_TRADES_FILE
+TRADE_LOG_FILE = COMPLETED_TRADES_FILE
+
+module_dir = os.path.dirname(os.path.abspath(__file__))
+ensure_symlink(TRADE_LEARNING_LOG_FILE, os.path.join(module_dir, "trade_learning_log.csv"))
+ensure_symlink(TRADE_LEARNING_LOG_FILE, os.path.join(module_dir, "trade_logs.csv"))
+
+
+def log_trade_result(*args, **kwargs):
+    """Deprecated wrapper for compatibility.
+
+    Calls :func:`trade_storage.log_trade_result` after emitting a
+    ``DeprecationWarning``.  New code should import and use
+    ``log_trade_result`` directly from ``trade_storage``.
     """
-    Append the result of a completed trade to the learning log.
 
-    Parameters
-    ----------
-    trade : dict
-        A dictionary describing the trade.  Required keys include:
-        ``symbol``, ``direction``, ``confidence``, ``score``, ``session``,
-        ``btc_dominance``, ``fear_greed``, ``sentiment_bias`` and
-        ``sentiment_confidence``.  Optional keys include ``pattern``,
-        ``support_zone``, ``resistance_zone`` and ``volume``.
-    outcome : str
-        The result of the trade (e.g., "win", "loss", "breakeven").
-    **kwargs : Any
-        Additional keyword arguments are accepted for compatibility (e.g.,
-        ``exit_price``) but are ignored by the logger.
-    """
-    log_file = TRADE_LEARNING_LOG_FILE
-
-    module_dir = os.path.dirname(os.path.abspath(__file__))
-    ensure_symlink(log_file, os.path.join(module_dir, "trade_learning_log.csv"))
-    ensure_symlink(log_file, os.path.join(module_dir, "trade_logs.csv"))
-    fields = [
-        "timestamp",
-        "symbol",
-        "session",
-        "score",
-        "direction",
-        "outcome",
-        "btc_dominance",
-        "fear_greed",
-        "sentiment_bias",
-        "pattern",
-        "support_zone",
-        "resistance_zone",
-        "volume",
-        "confidence",
-    ]
-
-    # Compose the row with sensible defaults for missing fields
-    row = {
-        "timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
-        "symbol": trade.get("symbol"),
-        "session": trade.get("session", "unknown"),
-        # Score reflects the normalized technical score at entry time
-        "score": trade.get("score", trade.get("confidence", 0)),
-        "direction": trade.get("direction", "long"),
-        "outcome": outcome,
-        "btc_dominance": trade.get("btc_dominance", 0),
-        "fear_greed": trade.get("fear_greed", 0),
-        "sentiment_bias": trade.get("sentiment_bias", "unknown"),
-        # Use the chart/candlestick pattern detected when the trade was opened
-        "pattern": trade.get("pattern", trade.get("pattern_name", "none")),
-        "support_zone": trade.get("support_zone", False),
-        "resistance_zone": trade.get("resistance_zone", False),
-        "volume": trade.get("volume", 0),
-        # Confidence is the final blended confidence at entry time
-        "confidence": trade.get("confidence", trade.get("sentiment_confidence", 0)),
-    }
-
-    file_exists = os.path.isfile(log_file)
-    # Ensure parent directory exists
-    os.makedirs(os.path.dirname(log_file), exist_ok=True)
-    with open(log_file, mode="a", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=fields)
-        if not file_exists:
-            writer.writeheader()
-        writer.writerow(row)
+    warnings.warn(
+        "trade_logger.log_trade_result is deprecated; import from trade_storage instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _storage_log_trade_result(*args, **kwargs)


### PR DESCRIPTION
## Summary
- Import `COMPLETED_TRADES_FILE` in learning modules to use unified trade log
- Deprecate `trade_logger.log_trade_result` in favor of `trade_storage`
- Update documentation and symlinks to reflect completed trade log

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a98d167d90832daf5d4b55b76e093a