### PR TITLE
Log extended sentiment and technical fields for trades

### DIFF
--- a/ml_model.py
+++ b/ml_model.py
@@ -107,11 +107,16 @@ def _extract_features(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
             session = row.get("session", "unknown")
             btc_dom = float(row.get("btc_dominance", 0))
             fg = float(row.get("fear_greed", 0))
-            sent_conf = row.get("sentiment_confidence", row.get("sentiment", 5))
+            sent_conf = row.get("sentiment_confidence", row.get("confidence", 5))
             try:
                 sent_conf_val = float(sent_conf)
             except Exception:
                 sent_conf_val = 5.0
+            sent_bias = row.get("sentiment_bias", "neutral")
+            sent_bias_val = {
+                "bullish": 1.0,
+                "bearish": -1.0,
+            }.get(str(sent_bias).lower(), 0.0)
             pattern = row.get("pattern", "none")
             pattern_len = len(str(pattern))
             session_id = session_map.get(str(session), 3)
@@ -135,6 +140,7 @@ def _extract_features(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
                 btc_dom / 100.0,
                 fg / 100.0,
                 sent_conf_val / 10.0,
+                sent_bias_val,
                 pattern_len / 10.0,
                 volatility,
                 htf_trend,

--- a/trade_storage.py
+++ b/trade_storage.py
@@ -247,9 +247,15 @@ def log_trade_result(
         "confidence",
         "btc_dominance",
         "fear_greed",
+        "sentiment_bias",
+        "sentiment_confidence",
         "score",
         "pattern",
         "narrative",
+        "volatility",
+        "htf_trend",
+        "order_imbalance",
+        "macro_indicator",
     ]
     # Compose row
     entry_price = trade.get("entry")
@@ -283,9 +289,17 @@ def log_trade_result(
         "confidence": trade.get("confidence", 0),
         "btc_dominance": trade.get("btc_dominance", 0),
         "fear_greed": trade.get("fear_greed", 0),
+        "sentiment_bias": trade.get("sentiment_bias", "neutral"),
+        "sentiment_confidence": trade.get(
+            "sentiment_confidence", trade.get("confidence", 0)
+        ),
         "score": trade.get("score", trade.get("strength", 0)),
         "pattern": trade.get("pattern", "None"),
         "narrative": trade.get("narrative", "No explanation"),
+        "volatility": trade.get("volatility", 0),
+        "htf_trend": trade.get("htf_trend", 0),
+        "order_imbalance": trade.get("order_imbalance", 0),
+        "macro_indicator": trade.get("macro_indicator", 0),
     }
     if DB_CURSOR:
         try:


### PR DESCRIPTION
## Summary
- Log sentiment bias/confidence and optional technical metrics when storing trade results
- Populate new trade fields for volatility, trend, order imbalance and macro indicator
- Extend ML feature extraction to use sentiment bias and confidence fallbacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99984dd90832d9e3fc732face76b8