### PR TITLE
Prevent duplicate trades

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -586,16 +586,18 @@ def run_agent_loop() -> None:
                             tp2,
                             tp3,
                         )
-                        # Add to active trades and persist
-                        active_trades.append(new_trade)
-                        create_new_trade(new_trade)
-                        # Do NOT log the open trade as a completed trade.  It will be logged upon exit by trade_manager.py.
-                        save_active_trades(active_trades)
-                        send_email(
-                            f"New Trade Opened: {symbol}",
-                            f"{new_trade}\n\n Narrative:\n{narrative}\n\nNews Summary:\n{decision_obj.get('news_summary', '')}",
-                        )
-                        opened_count += 1
+                        # Add to active trades and persist if not a duplicate
+                        if create_new_trade(new_trade):
+                            active_trades.append(new_trade)
+                            # Do NOT log the open trade as a completed trade.  It will be logged upon exit by trade_manager.py.
+                            save_active_trades(active_trades)
+                            send_email(
+                                f"New Trade Opened: {symbol}",
+                                f"{new_trade}\n\n Narrative:\n{narrative}\n\nNews Summary:\n{decision_obj.get('news_summary', '')}",
+                            )
+                            opened_count += 1
+                        else:
+                            logger.info("Trade for %s already active; skipping new entry", symbol)
                     except Exception as e:
                         logger.error("Error opening trade for %s: %s", symbol, e, exc_info=True)
             # Manage existing trades after opening new ones

--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import trade_storage
+import trade_manager
 import csv
 
 
@@ -37,3 +38,13 @@ def test_log_trade_result_extended_fields(tmp_path, monkeypatch):
     assert rows[0]["sentiment_confidence"] == "8.0"
     assert "volatility" in rows[0]
     assert "macro_indicator" in rows[0]
+
+
+def test_duplicate_trade_guard(tmp_path, monkeypatch):
+    path = tmp_path / "active.json"
+    monkeypatch.setattr(trade_storage, "ACTIVE_TRADES_FILE", str(path))
+    trade = {"symbol": "BTCUSDT", "entry": 100, "direction": "long"}
+    assert trade_manager.create_new_trade(trade) is True
+    assert trade_manager.create_new_trade(trade) is False
+    trades = trade_storage.load_active_trades()
+    assert len(trades) == 1

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -29,6 +29,7 @@ from trade_storage import (
     remove_trade,
     load_active_trades,
     save_active_trades,
+    is_trade_active,
 )
 from rl_policy import RLPositionSizer
 
@@ -58,9 +59,21 @@ def _update_rl(trade: dict, exit_price: float) -> None:
         pass
 
 
-def create_new_trade(trade: dict) -> None:
-    """Add a new trade to persistent storage."""
+def create_new_trade(trade: dict) -> bool:
+    """Add a new trade to persistent storage if not already active.
+
+    Returns
+    -------
+    bool
+        ``True`` if the trade was stored, ``False`` if a trade with the
+        same symbol was already active.
+    """
+    symbol = trade.get("symbol")
+    if symbol and is_trade_active(symbol):
+        logger.info("Trade for %s already active; skipping new entry.", symbol)
+        return False
     store_trade(trade)
+    return True
 
 
 def should_exit_early(trade: dict, current_price: float, price_data) -> Tuple[bool, Optional[str]]:


### PR DESCRIPTION
## Summary
- Prevent storing duplicate trades by checking is_trade_active before persistence
- Only append new trades to active list when storage succeeds
- Test that duplicate trade entries are ignored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9e86a4758832da834e98887169a71