### PR TITLE
Avoid duplicate active trades by replacing existing entries

### DIFF
--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -48,3 +48,15 @@ def test_duplicate_trade_guard(tmp_path, monkeypatch):
     assert trade_manager.create_new_trade(trade) is False
     trades = trade_storage.load_active_trades()
     assert len(trades) == 1
+
+
+def test_store_trade_replaces_existing(tmp_path, monkeypatch):
+    path = tmp_path / "active.json"
+    monkeypatch.setattr(trade_storage, "ACTIVE_TRADES_FILE", str(path))
+    first = {"symbol": "ETHUSDT", "entry": 100}
+    second = {"symbol": "ETHUSDT", "entry": 200}
+    trade_storage.store_trade(first)
+    trade_storage.store_trade(second)
+    trades = trade_storage.load_active_trades()
+    assert len(trades) == 1
+    assert trades[0]["entry"] == 200

--- a/trade_storage.py
+++ b/trade_storage.py
@@ -160,7 +160,7 @@ def is_trade_active(symbol: str) -> bool:
 
 
 def store_trade(trade: dict) -> None:
-    """Append a new trade to the active trades list."""
+    """Store ``trade`` in the active trades list, replacing duplicates."""
     # Ensure entry_time is set
     if "entry_time" not in trade:
         trade["entry_time"] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
@@ -180,6 +180,9 @@ def store_trade(trade: dict) -> None:
         except Exception as exc:
             logger.exception("Failed to store trade in database: %s", exc)
     trades = load_active_trades()
+    symbol = trade.get("symbol")
+    # Remove any existing trade with the same symbol
+    trades = [t for t in trades if t.get("symbol") != symbol]
     trades.append(trade)
     save_active_trades(trades)
 


### PR DESCRIPTION
## Summary
- Ensure `store_trade` removes any existing trade with the same symbol before saving
- Add regression test confirming file-based storage replaces duplicates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9e99b7ef8832db011f7ae91609807