### PR TITLE
Add duplicate trade guard to storage and trade creation logic

### DIFF
--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -50,13 +50,13 @@ def test_duplicate_trade_guard(tmp_path, monkeypatch):
     assert len(trades) == 1
 
 
-def test_store_trade_replaces_existing(tmp_path, monkeypatch):
+def test_store_trade_skips_duplicates(tmp_path, monkeypatch):
     path = tmp_path / "active.json"
     monkeypatch.setattr(trade_storage, "ACTIVE_TRADES_FILE", str(path))
     first = {"symbol": "ETHUSDT", "entry": 100}
     second = {"symbol": "ETHUSDT", "entry": 200}
-    trade_storage.store_trade(first)
-    trade_storage.store_trade(second)
+    assert trade_storage.store_trade(first) is True
+    assert trade_storage.store_trade(second) is False
     trades = trade_storage.load_active_trades()
     assert len(trades) == 1
-    assert trades[0]["entry"] == 200
+    assert trades[0]["entry"] == 100

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -72,8 +72,7 @@ def create_new_trade(trade: dict) -> bool:
     if symbol and is_trade_active(symbol):
         logger.info("Trade for %s already active; skipping new entry.", symbol)
         return False
-    store_trade(trade)
-    return True
+    return store_trade(trade)
 
 
 def should_exit_early(trade: dict, current_price: float, price_data) -> Tuple[bool, Optional[str]]:


### PR DESCRIPTION
## Summary
- Prevent storing duplicate active trades by checking existing entries before saving
- Propagate storage result in `create_new_trade` to ensure duplicates are skipped
- Test coverage for duplicate guard and storage behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9ed1c01d4832d94b94e59f4259969