### PR TITLE
feat: add Binance price backtest support

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -187,3 +187,34 @@ def grid_search(backtester: Backtester, param_grid: Dict[str, List[Any]]) -> Dic
             best_perf = perf
             best_params = params
     return {'best_params': best_params, 'performance': best_perf}
+
+
+def compute_buy_and_hold_pnl(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute buy-and-hold returns from a Binance OHLCV dataframe.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing at least a ``close`` column with price data.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``df`` augmented with ``pnl`` (period returns) and
+        ``equity`` (cumulative equity) columns.
+
+    Notes
+    -----
+    The function assumes consecutive rows represent equally spaced time
+    periods.  Returns are computed as percentage change of the close
+    price and a starting equity of 1.0 is assumed.
+    """
+
+    if "close" not in df.columns:
+        raise ValueError("DataFrame must contain a 'close' column")
+
+    out = df.copy()
+    close = out["close"].astype(float)
+    out["pnl"] = close.pct_change().fillna(0.0)
+    out["equity"] = (1 + out["pnl"]).cumprod()
+    return out

--- a/tests/test_binance_pnl.py
+++ b/tests/test_binance_pnl.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from backtest import compute_buy_and_hold_pnl
+from pytest import approx
+
+
+def test_compute_buy_and_hold_pnl():
+    df = pd.DataFrame({'close': [100, 110, 105]})
+    out = compute_buy_and_hold_pnl(df)
+    assert 'pnl' in out.columns
+    assert 'equity' in out.columns
+    # First return should be 0, second 0.1, third about -0.04545
+    expected_pnl = [0.0, 0.1, -0.045454545454545456]
+    assert out['pnl'].tolist() == approx(expected_pnl)
+    expected_equity = [1.0, 1.1, 1.05]
+    assert out['equity'].tolist() == approx(expected_equity)


### PR DESCRIPTION
## Summary
- allow dashboard backtest tab to accept Binance OHLCV CSVs and compute buy-and-hold equity
- add helper to compute PnL/equity from close prices
- cover buy-and-hold calculation with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad8d93d84832db768823b50372c16