### PR TITLE
Add On-Balance Volume indicator

### DIFF
--- a/tests/test_obv.py
+++ b/tests/test_obv.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from trade_utils import OnBalanceVolumeIndicator
+
+def test_on_balance_volume_indicator():
+    df = pd.DataFrame({
+        "close": [10, 11, 10, 12, 12],
+        "volume": [100, 150, 200, 100, 120],
+    })
+    obv = OnBalanceVolumeIndicator(df["close"], df["volume"]).on_balance_volume()
+    assert obv.tolist() == [0, 150, -50, 50, 50]


### PR DESCRIPTION
## Summary
- add On Balance Volume indicator with fallbacks and calculation helper
- cover OBV computation with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acdabe871c832d81b98bf598987843