### PR TITLE
feat: add indicator weight sanity check

### DIFF
--- a/tests/test_weight_optimizer.py
+++ b/tests/test_weight_optimizer.py
@@ -1,0 +1,26 @@
+import importlib
+import pandas as pd
+
+def test_optimize_indicator_weights(monkeypatch, tmp_path):
+    sig_file = tmp_path / "signal_log.csv"
+    trade_file = tmp_path / "trade_log.csv"
+    pd.DataFrame({
+        "timestamp": ["2024-01-01 00:00:00", "2024-01-01 01:00:00", "2024-01-01 02:00:00"],
+        "symbol": ["BTCUSDT", "BTCUSDT", "BTCUSDT"],
+        "ema_trigger": [1, 1, 0],
+        "macd_trigger": [1, 0, 1],
+    }).to_csv(sig_file, index=False)
+    pd.DataFrame({
+        "timestamp": ["2024-01-01 00:00:00", "2024-01-01 01:00:00", "2024-01-01 02:00:00"],
+        "symbol": ["BTCUSDT", "BTCUSDT", "BTCUSDT"],
+        "outcome": ["win", "loss", "win"],
+    }).to_csv(trade_file, index=False)
+    monkeypatch.setenv("SIGNAL_LOG_FILE", str(sig_file))
+    monkeypatch.setenv("TRADE_LOG_FILE", str(trade_file))
+    import trade_storage
+    importlib.reload(trade_storage)
+    weight_optimizer = importlib.reload(importlib.import_module("weight_optimizer"))
+    base = {"ema": 1.0, "macd": 1.0}
+    optimized = weight_optimizer.optimize_indicator_weights(base)
+    assert optimized["ema"] != base["ema"]
+    assert optimized["macd"] == base["macd"]

--- a/weight_optimizer.py
+++ b/weight_optimizer.py
@@ -1,0 +1,46 @@
+import os
+import pandas as pd
+from log_utils import setup_logger
+from trade_storage import TRADE_LOG_FILE
+
+_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+SIGNAL_LOG_FILE = os.getenv("SIGNAL_LOG_FILE", os.path.join(_MODULE_DIR, "signal_log.csv"))
+
+logger = setup_logger(__name__)
+
+def optimize_indicator_weights(base_weights: dict, lookback: int = 200) -> dict:
+    """Return adjusted indicator weights based on recent performance.
+
+    Reads the signal log and completed trade log, joins them on timestamp and symbol,
+    and calculates a simple win rate for each indicator. The base weight is scaled
+    by a factor between 0.5 and 1.0 depending on the win rate (0..1).
+    If insufficient data is available, the original weights are returned.
+    """
+    if not (os.path.exists(SIGNAL_LOG_FILE) and os.path.exists(TRADE_LOG_FILE)):
+        return base_weights
+    try:
+        signals = pd.read_csv(SIGNAL_LOG_FILE).tail(lookback)
+        trades = pd.read_csv(TRADE_LOG_FILE).tail(lookback)
+        merged = pd.merge(
+            signals,
+            trades[["timestamp", "symbol", "outcome"]],
+            on=["timestamp", "symbol"],
+            how="inner",
+        )
+        if merged.empty:
+            return base_weights
+        new_weights = base_weights.copy()
+        for key in base_weights.keys():
+            col = f"{key}_trigger"
+            if col not in merged.columns:
+                continue
+            triggered = merged[merged[col] > 0]
+            if triggered.empty:
+                continue
+            win_rate = (triggered["outcome"] == "win").mean()
+            if win_rate == win_rate:  # check for NaN
+                new_weights[key] = round(base_weights[key] * (0.5 + win_rate / 2), 3)
+        return new_weights
+    except Exception as exc:
+        logger.exception("Failed to optimize indicator weights: %s", exc)
+        return base_weights


### PR DESCRIPTION
## Summary
- add `optimize_indicator_weights` to adjust indicator weights using recent trade outcomes
- log indicator triggers for each signal and feed dynamic weights into evaluation
- test weight optimizer behavior with sample logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace44211e8832dbdfb0d1e66b10dba