### PR TITLE
Add context-aware score thresholds

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -439,10 +439,12 @@ def run_agent_loop() -> None:
                 )
                 # Symbol-specific volatility
                 try:
-                    sym_vol = atr_percentile(
+                    sym_vol_pct = atr_percentile(
                         price_data["high"], price_data["low"], price_data["close"]
-                    ) * 100.0
+                    )
+                    sym_vol = sym_vol_pct * 100.0
                 except Exception:
+                    sym_vol_pct = float("nan")
                     sym_vol = 0.0
                 # Ask the brain whether to take the trade
                 # Call the brain with error handling.  If the brain throws an
@@ -459,6 +461,8 @@ def run_agent_loop() -> None:
                         orderflow=orderflow,
                         sentiment=sentiment,
                         macro_news={"safe": True, "reason": ""},
+                        volatility=sym_vol_pct,
+                        fear_greed=fg,
                     )
                 except Exception as e:
                     logger.error("Error in should_trade for %s: %s", symbol, e, exc_info=True)

--- a/tests/test_signal_logic.py
+++ b/tests/test_signal_logic.py
@@ -47,3 +47,35 @@ def test_should_trade_auto_approves_on_llm_error():
     )
     assert result["decision"] is True
     assert "auto-approval" in result["reason"].lower()
+
+
+def test_should_trade_rejects_in_extreme_fear():
+    result = should_trade(
+        symbol="BTCUSDT",
+        score=6.0,
+        direction="long",
+        indicators={},
+        session="US",
+        pattern_name="",
+        orderflow="neutral",
+        sentiment={"bias": "neutral"},
+        macro_news={"safe": True, "reason": ""},
+        fear_greed=10,
+    )
+    assert result["decision"] is False
+
+
+def test_should_trade_demands_more_in_low_vol():
+    result = should_trade(
+        symbol="BTCUSDT",
+        score=5.6,
+        direction="long",
+        indicators={},
+        session="US",
+        pattern_name="",
+        orderflow="neutral",
+        sentiment={"bias": "neutral"},
+        macro_news={"safe": True, "reason": ""},
+        volatility=0.1,
+    )
+    assert result["decision"] is False


### PR DESCRIPTION
## Summary
- Consider symbol volatility and Fear & Greed index when evaluating trades
- Feed ATR percentile and sentiment data from the agent into the decision logic
- Cover new threshold behaviour for extreme fear and low volatility with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ace9376740832d8c294bdabf1c1bbe