### PR TITLE
feat: expand RL state with volatility regime

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -58,7 +58,7 @@ from sequence_model import predict_next_return, train_sequence_model, SEQ_PKL
 from drawdown_guard import is_trading_blocked
 import numpy as np
 from rl_policy import RLPositionSizer
-from trade_utils import get_last_trade_outcome
+from trade_utils import get_rl_state
 from volatility_regime import atr_percentile
 
 
@@ -523,7 +523,7 @@ def run_agent_loop() -> None:
                         else:
                             atr_val = entry_price * 0.02
                             base_size = risk_amt / (entry_price * 0.02)
-                        state = get_last_trade_outcome() or "neutral"
+                        state = get_rl_state(sym_vol_pct)
                         mult = rl_sizer.select_multiplier(state)
                         position_size = round(max(base_size * mult, 0), 6)
                         sl = round(entry_price - atr_val * 2.0, 6)

--- a/rl_policy.py
+++ b/rl_policy.py
@@ -4,11 +4,12 @@ Reinforcement‑learning based position sizing for the Spot‑AI Agent.
 This module implements a simple Q‑learning policy to adjust the
 position sizing multiplier based on recent trading outcomes.  The goal
 is to allocate more capital to high‑reward states and less to
-underperforming ones.  The state is defined by the previous trade
-outcome (``win`` or ``loss``), and the action space consists of
-discrete multipliers (e.g., ``[0.5, 1.0, 1.5]``).  Each action
-represents a fraction of the default position size computed by the
-agent.
+underperforming ones.  While the basic implementation uses only the
+previous trade outcome (``win``/``loss``/``neutral``) as the state, it
+also supports richer context such as volatility regimes.  The action
+space consists of discrete multipliers (e.g., ``[0.5, 1.0, 1.5, 2.0]``),
+each representing a fraction of the default position size computed by
+the agent.
 
 This lightweight RL approach is an approximation to more sophisticated
 actor–critic methods.  It learns a Q‑table mapping states and actions
@@ -19,9 +20,10 @@ tends to favour the multiplier that yields higher returns.
 Usage::
 
     from rl_policy import RLPositionSizer
+    from trade_utils import get_rl_state
     rl_sizer = RLPositionSizer()
-    # during trade entry
-    state = 'win' if last_trade_was_profitable else 'loss'
+    # during trade entry combine last outcome with volatility percentile
+    state = get_rl_state(vol_percentile)
     multiplier = rl_sizer.select_multiplier(state)
     position_size = base_size * multiplier
     ...

--- a/tests/test_rl_state.py
+++ b/tests/test_rl_state.py
@@ -1,0 +1,17 @@
+from trade_utils import get_rl_state
+
+
+def test_get_rl_state(tmp_path):
+    log = tmp_path / "trades.csv"
+    # last trade: win
+    log.write_text("2024-01-01 00:00:00,BTCUSDT,long,100,110,exit,0,0,0,bullish,0\n")
+    state_high = get_rl_state(0.9, log_file=str(log))
+    state_low = get_rl_state(0.1, log_file=str(log))
+    assert state_high == "win_high_vol"
+    assert state_low == "win_low_vol"
+
+
+def test_get_rl_state_no_history(tmp_path):
+    # No trade log -> neutral with volatility bucket
+    state = get_rl_state(0.5, log_file=str(tmp_path / "missing.csv"))
+    assert state == "neutral_mid_vol"


### PR DESCRIPTION
## Summary
- derive RL state from last trade outcome and ATR-based volatility bucket
- document richer state usage in `rl_policy` and update agent to consume new helper
- add tests for RL state construction

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `python3 -m pip install --break-system-packages pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6fceabac832d9d879051552990f9