### PR TITLE
Enable dashboard in deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ EMAIL_RECEIVER=recipient@example.com
 BINANCE_API_KEY=your_binance_api_key
 BINANCE_API_SECRET=your_binance_api_secret
 SIZE_AS_NOTIONAL=true
+RUN_DASHBOARD=1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Set the following environment variables as needed:
 - `BINANCE_API_KEY` / `BINANCE_API_SECRET`
 - `DATA_DIR` – optional override for trade storage. Defaults to
   `/home/ubuntu/spot_data/trades`.
-- `RUN_DASHBOARD` – set to `1` to launch the Streamlit dashboard from the agent
+- `RUN_DASHBOARD` – set to `1` to launch the Streamlit dashboard from the agent,
+  or `0` to rely on the separate `spot-ai-dashboard` service
 
 ## Sentiment Fusion
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,24 +1,24 @@
 services:
-  - type: web
-    name: spot-ai-trader
-    env: python
-    pythonVersion: 3.10.13
-    buildCommand: pip install -r requirements.txt
-    startCommand: python3 agent.py
-    healthCheckPath: /
-    envVars:
-      - key: RUN_DASHBOARD
-        value: "0"
-      - key: DATABASE_URL
-        fromDatabase:
-          name: spot-ai-db
-          property: connectionString
-      - key: DATA_DIR
-        value: /var/data
-    disks:
-      - name: trade-data
-        mountPath: /var/data
-        sizeGB: 1
+    - type: web
+      name: spot-ai-trader
+      env: python
+      pythonVersion: 3.10.13
+      buildCommand: pip install -r requirements.txt
+      startCommand: python3 agent.py
+      healthCheckPath: /
+      envVars:
+        - key: RUN_DASHBOARD
+          value: "1"
+        - key: DATABASE_URL
+          fromDatabase:
+            name: spot-ai-db
+            property: connectionString
+        - key: DATA_DIR
+          value: /var/data
+      disks:
+        - name: trade-data
+          mountPath: /var/data
+          sizeGB: 1
   - type: web
     name: spot-ai-dashboard
     env: python


### PR DESCRIPTION
## Summary
- enable Streamlit dashboard by default in render deployment via `RUN_DASHBOARD=1`
- document dashboard toggle and separate service option
- include `RUN_DASHBOARD` in example env file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b312b02278832d83b7eafc51b323df