### PR TITLE
Use OCO orders for take-profit and stop-loss updates

### DIFF
--- a/tests/test_stop_loss_update.py
+++ b/tests/test_stop_loss_update.py
@@ -5,35 +5,38 @@ import trade_utils
 def test_update_stop_loss_calls_util(monkeypatch):
     calls = {}
 
-    def fake_update(symbol, qty, price, existing):
-        calls['args'] = (symbol, qty, price, existing)
+    def fake_update(symbol, qty, price, existing, tp):
+        calls['args'] = (symbol, qty, price, existing, tp)
         return '123'
 
     monkeypatch.setattr(trade_manager, 'update_stop_loss_order', fake_update)
-    trade = {'symbol': 'BTCUSDT', 'size': 1, 'sl': 100}
+    trade = {'symbol': 'BTCUSDT', 'size': 1, 'sl': 100, 'tp1': 110, 'status': {'tp1': False}}
     trade_manager._update_stop_loss(trade, 90)
     assert trade['sl'] == 90
     assert trade['sl_order_id'] == '123'
-    assert calls['args'] == ('BTCUSDT', 1.0, 90, None)
+    assert calls['args'] == ('BTCUSDT', 1.0, 90, None, 110)
 
 
 def test_update_stop_loss_order_places_and_cancels(monkeypatch):
     class DummyClient:
         def __init__(self):
             self.cancel_args = None
-            self.create_kwargs = None
+            self.oco_kwargs = None
 
-        def cancel_order(self, symbol, orderId):
-            self.cancel_args = (symbol, orderId)
+        def cancel_oco_order(self, symbol, orderListId):
+            self.cancel_args = (symbol, orderListId)
 
-        def create_order(self, **kwargs):
-            self.create_kwargs = kwargs
-            return {'orderId': 456}
+        def create_oco_order(self, **kwargs):
+            self.oco_kwargs = kwargs
+            return {'orderListId': 789}
 
     dummy = DummyClient()
     monkeypatch.setattr(trade_utils, 'client', dummy)
-    order_id = trade_utils.update_stop_loss_order('BTCUSDT', 0.5, 25000.0, existing_order_id=1)
-    assert order_id == 456
+    order_id = trade_utils.update_stop_loss_order(
+        'BTCUSDT', 0.5, 25000.0, existing_order_id=1, take_profit_price=30000.0
+    )
+    assert order_id == 789
     assert dummy.cancel_args == ('BTCUSDT', 1)
-    assert dummy.create_kwargs['symbol'] == 'BTCUSDT'
-    assert dummy.create_kwargs['stopPrice'] == 25000.0
+    assert dummy.oco_kwargs['symbol'] == 'BTCUSDT'
+    assert dummy.oco_kwargs['price'] == 30000.0
+    assert dummy.oco_kwargs['stopPrice'] == 25000.0

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -73,8 +73,16 @@ def _update_stop_loss(trade: dict, new_sl: float) -> None:
     except Exception:
         qty = 1.0
     order_id = trade.get("sl_order_id")
+    status = trade.get("status", {})
+    tp_price = None
+    if not status.get("tp1"):
+        tp_price = trade.get("tp1")
+    elif not status.get("tp2"):
+        tp_price = trade.get("tp2")
+    elif not status.get("tp3"):
+        tp_price = trade.get("tp3")
     if symbol:
-        new_id = update_stop_loss_order(symbol, qty, new_sl, order_id)
+        new_id = update_stop_loss_order(symbol, qty, new_sl, order_id, tp_price)
         if new_id is not None:
             trade["sl_order_id"] = new_id
     trade["sl"] = new_sl


### PR DESCRIPTION
## Summary
- Support Binance OCO orders to pair take-profit and stop-loss levels
- Trail stop-loss by cancelling and recreating OCO/stop orders when `trade['sl']` changes
- Add tests covering OCO order placement and stop-loss updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e014df74832d8734fa60dddc3e45