### PR TITLE
Refine initial take-profit to 1x ATR

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -566,9 +566,9 @@ def run_agent_loop() -> None:
                         mult = rl_sizer.select_multiplier(state)
                         position_size = round(max(base_size * mult, 0), 6)
                         sl = round(entry_price - atr_val * 2.0, 6)
-                        tp1 = round(entry_price + atr_val * 2.0, 6)
-                        tp2 = round(entry_price + atr_val * 3.0, 6)
-                        tp3 = round(entry_price + atr_val * 4.0, 6)
+                        tp1 = round(entry_price + atr_val * 1.0, 6)
+                        tp2 = round(entry_price + atr_val * 2.0, 6)
+                        tp3 = round(entry_price + atr_val * 3.0, 6)
                         try:
                             ema20 = indicators_df['ema_20'].iloc[-1]
                             ema50 = indicators_df['ema_50'].iloc[-1]


### PR DESCRIPTION
## Summary
- Use 1×ATR for the first take-profit level so profits can be secured sooner
- Cascade later take-profit targets to 2×ATR and 3×ATR

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e2bc2790832d940f242e53b86361