### PR TITLE
test: ensure consistent trade paths

### DIFF
--- a/tests/test_trade_paths.py
+++ b/tests/test_trade_paths.py
@@ -1,0 +1,31 @@
+import importlib
+import pandas as pd
+import trade_storage
+
+
+def test_trade_paths(monkeypatch, tmp_path):
+    try:
+        import binance.client
+        class DummyClient:
+            def __init__(self, *args, **kwargs):
+                pass
+        monkeypatch.setattr(binance.client, "Client", DummyClient)
+    except Exception:
+        pass
+    agent = importlib.import_module("agent")
+    dashboard = importlib.import_module("dashboard")
+    assert agent.ACTIVE_TRADES_FILE == trade_storage.ACTIVE_TRADES_FILE
+    assert dashboard.ACTIVE_TRADES_FILE == trade_storage.ACTIVE_TRADES_FILE
+    completed_path = tmp_path / "completed.csv"
+    other_path = tmp_path / "other.csv"
+    monkeypatch.setattr(trade_storage, "COMPLETED_TRADES_FILE", str(completed_path))
+    monkeypatch.setattr(trade_storage, "TRADE_LOG_FILE", str(other_path))
+    monkeypatch.setattr(trade_storage.os.path, "exists", lambda p: True)
+    monkeypatch.setattr(trade_storage.os.path, "getsize", lambda p: 1)
+    captured = {}
+    def fake_read_csv(path, *args, **kwargs):
+        captured["path"] = path
+        return pd.DataFrame()
+    monkeypatch.setattr(trade_storage.pd, "read_csv", fake_read_csv)
+    trade_storage.load_trade_history_df()
+    assert captured["path"] == str(completed_path)

--- a/trade_storage.py
+++ b/trade_storage.py
@@ -360,9 +360,10 @@ def load_trade_history_df() -> pd.DataFrame:
         except Exception as exc:
             logger.exception("Failed to load trade history from database: %s", exc)
     else:
-        if os.path.exists(TRADE_LOG_FILE) and os.path.getsize(TRADE_LOG_FILE) > 0:
+        path = COMPLETED_TRADES_FILE
+        if os.path.exists(path) and os.path.getsize(path) > 0:
             try:
-                df = pd.read_csv(TRADE_LOG_FILE, encoding="utf-8")
+                df = pd.read_csv(path, encoding="utf-8")
             except Exception as exc:
                 logger.exception("Failed to read trade log file: %s", exc)
         else:


### PR DESCRIPTION
## Summary
- add regression test verifying all modules use identical trade file paths
- fix `load_trade_history_df` to read from the canonical `COMPLETED_TRADES_FILE`

## Testing
- `pytest tests/test_trade_paths.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7644fddc4832da7e2e8c5367b426d