### PR TITLE
refactor: unify trade history path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ BINANCE_API_KEY=your_binance_api_key
 BINANCE_API_SECRET=your_binance_api_secret
 SIZE_AS_NOTIONAL=true
 RUN_DASHBOARD=1
+TRADE_HISTORY_FILE=/home/ubuntu/spot_data/trades/completed_trades.csv
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Set the following environment variables as needed:
 - `BINANCE_API_KEY` / `BINANCE_API_SECRET`
 - `DATA_DIR` – optional override for trade storage. Defaults to
   `/home/ubuntu/spot_data/trades`.
+- `TRADE_HISTORY_FILE` – optional override for the unified completed trades log.
+  Defaults to `/home/ubuntu/spot_data/trades/completed_trades.csv`.
 - `RUN_DASHBOARD` – set to `1` to launch the Streamlit dashboard from the agent,
   or `0` to rely on the separate `spot-ai-dashboard` service
 

--- a/agent.py
+++ b/agent.py
@@ -42,7 +42,7 @@ from trade_storage import (
     load_active_trades,
     save_active_trades,
     ACTIVE_TRADES_FILE,
-    COMPLETED_TRADES_FILE,
+    TRADE_HISTORY_FILE,
     log_trade_result,
 )
 from notifier import send_email, log_rejection, REJECTED_TRADES_FILE
@@ -81,9 +81,9 @@ RUN_DASHBOARD = os.getenv("RUN_DASHBOARD", "0") == "1"
 rl_sizer = RLPositionSizer()
 
 logger.info(
-    "Paths: LOG_FILE=%s COMPLETED_TRADES=%s ACTIVE_TRADES=%s REJECTED_TRADES=%s LEARNING_LOG=%s",
+    "Paths: LOG_FILE=%s TRADE_HISTORY=%s ACTIVE_TRADES=%s REJECTED_TRADES=%s LEARNING_LOG=%s",
     LOG_FILE,
-    COMPLETED_TRADES_FILE,
+    TRADE_HISTORY_FILE,
     ACTIVE_TRADES_FILE,
     REJECTED_TRADES_FILE,
     TRADE_LEARNING_LOG_FILE,

--- a/confidence.py
+++ b/confidence.py
@@ -3,7 +3,7 @@ Historical confidence calculator for trade outcomes.
 
 This module provides a function to compute a confidence estimate for a
 potential trade based on past performance recorded in the completed
-trades log (``COMPLETED_TRADES_FILE``).
+trades log (``TRADE_HISTORY_FILE``).
 It reads the log with tolerant parsing (skipping bad lines) and filters
 similar trades by symbol, direction, score range and session.  The
 confidence is scaled between 0 and 100 and includes a small boost if
@@ -13,10 +13,10 @@ recent trades show better performance.
 import pandas as pd
 import os
 
-from trade_storage import COMPLETED_TRADES_FILE
+from trade_storage import TRADE_HISTORY_FILE
 
 # Path to the completed trades log for historical confidence calculations
-LOG_FILE = COMPLETED_TRADES_FILE
+LOG_FILE = TRADE_HISTORY_FILE
 
 
 def calculate_historical_confidence(symbol, score, direction, session="Unknown", pattern_name=None):

--- a/confidence_guard.py
+++ b/confidence_guard.py
@@ -11,10 +11,10 @@ brain/decision logic to calibrate how strict the bot should be.
 import pandas as pd
 import os
 
-from trade_storage import COMPLETED_TRADES_FILE
+from trade_storage import TRADE_HISTORY_FILE
 
 # Path to the completed trades log used for adaptive thresholding
-LEARNING_LOG = COMPLETED_TRADES_FILE
+LEARNING_LOG = TRADE_HISTORY_FILE
 
 
 def get_adaptive_conf_threshold() -> float:

--- a/dashboard.py
+++ b/dashboard.py
@@ -122,7 +122,7 @@ from trade_storage import (
     load_active_trades,
     log_trade_result,
     load_trade_history_df,
-    COMPLETED_TRADES_FILE,
+    TRADE_HISTORY_FILE,
     ACTIVE_TRADES_FILE,
 )
 from notifier import REJECTED_TRADES_FILE
@@ -147,9 +147,9 @@ st.set_page_config(
 )
 logger = setup_logger(__name__)
 logger.info(
-    "Paths: LOG_FILE=%s COMPLETED_TRADES=%s ACTIVE_TRADES=%s REJECTED_TRADES=%s LEARNING_LOG=%s",
+    "Paths: LOG_FILE=%s TRADE_HISTORY=%s ACTIVE_TRADES=%s REJECTED_TRADES=%s LEARNING_LOG=%s",
     LOG_FILE,
-    COMPLETED_TRADES_FILE,
+    TRADE_HISTORY_FILE,
     ACTIVE_TRADES_FILE,
     REJECTED_TRADES_FILE,
     TRADE_LEARNING_LOG_FILE,
@@ -831,7 +831,7 @@ def render_backtest_tab() -> None:
                     exit_time=t["exit_time"].strftime("%Y-%m-%d %H:%M:%S"),
                 )
             st.success(
-                f"Backtest generated {len(trades)} trades; results appended to {COMPLETED_TRADES_FILE}"
+                f"Backtest generated {len(trades)} trades; results appended to {TRADE_HISTORY_FILE}"
             )
             train_model()
             st.info("Model training complete. Check logs for details.")

--- a/memory_retriever.py
+++ b/memory_retriever.py
@@ -2,7 +2,7 @@
 Utilities for retrieving past trade memories.
 
 This module provides helper functions to summarise recent trades from the
-completed trades log (``COMPLETED_TRADES_FILE``).  The summary can be used to give the LLM context
+completed trades log (``TRADE_HISTORY_FILE``).  The summary can be used to give the LLM context
 about similar past trades, enabling it to reason based on prior
 experience (retrieval‑augmented generation).
 """
@@ -13,10 +13,10 @@ import os
 from typing import Optional
 
 import pandas as pd
-from trade_storage import COMPLETED_TRADES_FILE
+from trade_storage import TRADE_HISTORY_FILE
 
 # Path to the completed trades log used for memory retrieval
-LOG_FILE = COMPLETED_TRADES_FILE
+LOG_FILE = TRADE_HISTORY_FILE
 
 
 def get_recent_trade_summary(symbol: str, pattern: str, max_entries: int = 3) -> str:

--- a/ml_model.py
+++ b/ml_model.py
@@ -45,7 +45,7 @@ import numpy as np
 import pandas as pd
 from datetime import datetime
 from log_utils import setup_logger
-from trade_storage import COMPLETED_TRADES_FILE, load_trade_history_df
+from trade_storage import TRADE_HISTORY_FILE, load_trade_history_df
 
 try:
     # Core sklearn components used for modelling and preprocessing
@@ -90,7 +90,7 @@ logger = setup_logger(__name__)
 # ---------------------------------------------------------------------------
 
 ROOT_DIR = os.path.dirname(__file__)
-LOG_FILE = COMPLETED_TRADES_FILE
+LOG_FILE = TRADE_HISTORY_FILE
 MODEL_JSON = os.path.join(ROOT_DIR, "ml_model.json")
 MODEL_PKL = os.path.join(ROOT_DIR, "ml_model.pkl")
 
@@ -205,7 +205,7 @@ def train_model(iterations: int = 200, learning_rate: float = 0.1) -> None:
 
     If scikit‑learn is available, this function performs the following:
     1. Extracts features and labels from the completed trades log
-       (``COMPLETED_TRADES_FILE``).
+       (``TRADE_HISTORY_FILE``).
     2. Scales the features using ``StandardScaler``.
     3. Defines a grid of candidate models (logistic regression,
        random forest and gradient boosting) along with hyper‑parameter

--- a/tests/test_dashboard_paths.py
+++ b/tests/test_dashboard_paths.py
@@ -13,4 +13,4 @@ def test_dashboard_paths(monkeypatch):
         pass
     dashboard = importlib.import_module("dashboard")
     assert dashboard.ACTIVE_TRADES_FILE == trade_storage.ACTIVE_TRADES_FILE
-    assert dashboard.COMPLETED_TRADES_FILE == trade_storage.COMPLETED_TRADES_FILE
+    assert dashboard.TRADE_HISTORY_FILE == trade_storage.TRADE_HISTORY_FILE

--- a/tests/test_trade_paths.py
+++ b/tests/test_trade_paths.py
@@ -16,10 +16,10 @@ def test_trade_paths(monkeypatch, tmp_path):
     dashboard = importlib.import_module("dashboard")
     assert agent.ACTIVE_TRADES_FILE == trade_storage.ACTIVE_TRADES_FILE
     assert dashboard.ACTIVE_TRADES_FILE == trade_storage.ACTIVE_TRADES_FILE
+    assert agent.TRADE_HISTORY_FILE == trade_storage.TRADE_HISTORY_FILE
+    assert dashboard.TRADE_HISTORY_FILE == trade_storage.TRADE_HISTORY_FILE
     completed_path = tmp_path / "completed.csv"
-    other_path = tmp_path / "other.csv"
-    monkeypatch.setattr(trade_storage, "COMPLETED_TRADES_FILE", str(completed_path))
-    monkeypatch.setattr(trade_storage, "TRADE_LOG_FILE", str(other_path))
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(completed_path))
     monkeypatch.setattr(trade_storage.os.path, "exists", lambda p: True)
     monkeypatch.setattr(trade_storage.os.path, "getsize", lambda p: 1)
     captured = {}

--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -16,7 +16,7 @@ def test_save_and_load_active_trades(tmp_path, monkeypatch):
 
 def test_log_trade_result_extended_fields(tmp_path, monkeypatch):
     csv_path = tmp_path / "log.csv"
-    monkeypatch.setattr(trade_storage, "TRADE_LOG_FILE", str(csv_path))
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(csv_path))
     trade = {
         "symbol": "ETHUSDT",
         "direction": "long",

--- a/tests/test_weight_optimizer.py
+++ b/tests/test_weight_optimizer.py
@@ -16,7 +16,7 @@ def test_optimize_indicator_weights(monkeypatch, tmp_path):
         "outcome": ["win", "loss", "win"],
     }).to_csv(trade_file, index=False)
     monkeypatch.setenv("SIGNAL_LOG_FILE", str(sig_file))
-    monkeypatch.setenv("TRADE_LOG_FILE", str(trade_file))
+    monkeypatch.setenv("TRADE_HISTORY_FILE", str(trade_file))
     import trade_storage
     importlib.reload(trade_storage)
     weight_optimizer = importlib.reload(importlib.import_module("weight_optimizer"))

--- a/trade_logger.py
+++ b/trade_logger.py
@@ -11,13 +11,13 @@ import os
 import warnings
 from log_utils import ensure_symlink
 from trade_storage import (
-    COMPLETED_TRADES_FILE,
+    TRADE_HISTORY_FILE,
     log_trade_result as _storage_log_trade_result,
 )
 
 
-TRADE_LEARNING_LOG_FILE = COMPLETED_TRADES_FILE
-TRADE_LOG_FILE = COMPLETED_TRADES_FILE
+TRADE_LEARNING_LOG_FILE = TRADE_HISTORY_FILE
+TRADE_LOG_FILE = TRADE_HISTORY_FILE
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 ensure_symlink(TRADE_LEARNING_LOG_FILE, os.path.join(module_dir, "trade_learning_log.csv"))

--- a/trade_storage.py
+++ b/trade_storage.py
@@ -88,28 +88,31 @@ except OSError:
     DATA_DIR = DEFAULT_DATA_DIR
     os.makedirs(DATA_DIR, exist_ok=True)
 
-# File locations; these can be overridden individually via environment
-# variables if desired. ``ACTIVE_TRADES_FILE`` stores open trades in JSON
-# format. ``TRADE_LOG_FILE`` stores completed trades in CSV format.  Expose
-# these constants so other modules (e.g. ``trade_manager`` and ``dashboard``)
-# can import them, ensuring all components read and write the exact same files.
-# Canonical file locations within the data directory.  ``completed_trades.csv``
-# replaces the legacy ``trade_log.csv`` name; ``TRADE_LOG_FILE`` is kept as an
-# alias for backward compatibility.
+# File locations; ``ACTIVE_TRADES_FILE`` stores open trades in JSON format and
+# ``TRADE_HISTORY_FILE`` stores completed trades in CSV format.  The latter is
+# the canonical location for historical trade data and is configurable via the
+# ``TRADE_HISTORY_FILE`` environment variable.  Legacy constant names remain as
+# aliases for backward compatibility.
 ACTIVE_TRADES_FILE = os.environ.get(
     "ACTIVE_TRADES_FILE", os.path.join(DATA_DIR, "active_trades.json")
 ).split("#", 1)[0].strip()
-COMPLETED_TRADES_FILE = os.environ.get(
-    "COMPLETED_TRADES_FILE", os.path.join(DATA_DIR, "completed_trades.csv")
-).split("#", 1)[0].strip()
-TRADE_LOG_FILE = os.environ.get("TRADE_LOG_FILE", COMPLETED_TRADES_FILE)
+TRADE_HISTORY_FILE = (
+    os.environ.get(
+        "TRADE_HISTORY_FILE", os.path.join(DATA_DIR, "completed_trades.csv")
+    )
+    .split("#", 1)[0]
+    .strip()
+)
+# Backwards-compatible aliases
+COMPLETED_TRADES_FILE = TRADE_HISTORY_FILE
+TRADE_LOG_FILE = TRADE_HISTORY_FILE
 
 
 # Symlinks in the repository root allow read-only access for legacy code
 # that still expects files beside the source tree.
 _REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
 ensure_symlink(ACTIVE_TRADES_FILE, os.path.join(_REPO_ROOT, "active_trades.json"))
-ensure_symlink(COMPLETED_TRADES_FILE, os.path.join(_REPO_ROOT, "completed_trades.csv"))
+ensure_symlink(TRADE_HISTORY_FILE, os.path.join(_REPO_ROOT, "completed_trades.csv"))
 
 
 def load_active_trades() -> list:
@@ -337,11 +340,11 @@ def log_trade_result(
             return
         except Exception as exc:
             logger.exception("Failed to log trade result to database: %s", exc)
-    file_exists = os.path.exists(TRADE_LOG_FILE)
+    file_exists = os.path.exists(TRADE_HISTORY_FILE)
     # Ensure directory exists
-    os.makedirs(os.path.dirname(TRADE_LOG_FILE), exist_ok=True)
+    os.makedirs(os.path.dirname(TRADE_HISTORY_FILE), exist_ok=True)
     # Write the row to CSV
-    with open(TRADE_LOG_FILE, "a", newline="", encoding="utf-8") as f:
+    with open(TRADE_HISTORY_FILE, "a", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=headers)
         if not file_exists:
             writer.writeheader()
@@ -360,7 +363,7 @@ def load_trade_history_df() -> pd.DataFrame:
         except Exception as exc:
             logger.exception("Failed to load trade history from database: %s", exc)
     else:
-        path = COMPLETED_TRADES_FILE
+        path = TRADE_HISTORY_FILE
         if os.path.exists(path) and os.path.getsize(path) > 0:
             try:
                 df = pd.read_csv(path, encoding="utf-8")

--- a/trade_utils.py
+++ b/trade_utils.py
@@ -10,7 +10,7 @@ from log_utils import setup_logger
 
 from weight_optimizer import optimize_indicator_weights
 
-from trade_storage import TRADE_LOG_FILE  # shared trade log path
+from trade_storage import TRADE_HISTORY_FILE  # shared trade log path
 
 from volatility_regime import atr_percentile, hurst_exponent  # type: ignore
 from multi_timeframe import (
@@ -558,7 +558,7 @@ def get_top_symbols(limit: int = 30) -> list:
     symbols = [x['symbol'] for x in sorted_tickers if x['symbol'].endswith("USDT") and not x['symbol'].endswith("BUSD")]
     return symbols[:limit]
 
-def compute_performance_metrics(log_file: str = TRADE_LOG_FILE, lookback: int = 100) -> dict:
+def compute_performance_metrics(log_file: str = TRADE_HISTORY_FILE, lookback: int = 100) -> dict:
     """Return risk-adjusted performance metrics from the trade log."""
     if not os.path.exists(log_file):
         return {}
@@ -586,7 +586,7 @@ def compute_performance_metrics(log_file: str = TRADE_LOG_FILE, lookback: int = 
         return {}
 
 
-def get_last_trade_outcome(log_file: str = TRADE_LOG_FILE) -> str | None:
+def get_last_trade_outcome(log_file: str = TRADE_HISTORY_FILE) -> str | None:
     """Return ``'win'`` or ``'loss'`` based on the most recent closed trade.
 
     The helper is used by the RL position‑sizer to condition its action
@@ -612,7 +612,7 @@ def get_last_trade_outcome(log_file: str = TRADE_LOG_FILE) -> str | None:
     except Exception:
         return None
 
-def get_rl_state(vol_percentile: float | None, log_file: str = TRADE_LOG_FILE) -> str:
+def get_rl_state(vol_percentile: float | None, log_file: str = TRADE_HISTORY_FILE) -> str:
     """Construct a compound RL state from last outcome and volatility.
 
     The state combines the result of the most recently closed trade with a

--- a/weight_optimizer.py
+++ b/weight_optimizer.py
@@ -1,7 +1,7 @@
 import os
 import pandas as pd
 from log_utils import setup_logger
-from trade_storage import TRADE_LOG_FILE
+from trade_storage import TRADE_HISTORY_FILE
 
 _MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 SIGNAL_LOG_FILE = os.getenv("SIGNAL_LOG_FILE", os.path.join(_MODULE_DIR, "signal_log.csv"))
@@ -16,11 +16,11 @@ def optimize_indicator_weights(base_weights: dict, lookback: int = 200) -> dict:
     by a factor between 0.5 and 1.0 depending on the win rate (0..1).
     If insufficient data is available, the original weights are returned.
     """
-    if not (os.path.exists(SIGNAL_LOG_FILE) and os.path.exists(TRADE_LOG_FILE)):
+    if not (os.path.exists(SIGNAL_LOG_FILE) and os.path.exists(TRADE_HISTORY_FILE)):
         return base_weights
     try:
         signals = pd.read_csv(SIGNAL_LOG_FILE).tail(lookback)
-        trades = pd.read_csv(TRADE_LOG_FILE).tail(lookback)
+        trades = pd.read_csv(TRADE_HISTORY_FILE).tail(lookback)
         merged = pd.merge(
             signals,
             trades[["timestamp", "symbol", "outcome"]],


### PR DESCRIPTION
## Summary
- consolidate trade history configuration into `TRADE_HISTORY_FILE`
- update modules and tests to import canonical trade history path
- document `TRADE_HISTORY_FILE` in README and `.env.example`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7f4d8c610832d83873f41f2b0dbbc