### PR TITLE
fix trade history header handling

### DIFF
--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -41,6 +41,20 @@ def test_log_trade_result_extended_fields(tmp_path, monkeypatch):
     assert "llm_error" in rows[0]
 
 
+def test_log_trade_result_writes_header_if_file_empty(tmp_path, monkeypatch):
+    """Regression test for missing header when history file pre-exists."""
+    csv_path = tmp_path / "log.csv"
+    csv_path.touch()  # create zero-byte file
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(csv_path))
+    trade = {"symbol": "BTCUSDT", "direction": "long", "entry": 1000, "size": 1}
+    trade_storage.log_trade_result(trade, outcome="tp1", exit_price=1100)
+    with open(csv_path, newline="") as f:
+        rows = list(csv.DictReader(f))
+    # Without the header fix, ``rows`` would be empty because the first trade
+    # becomes the header.  We expect one row with a "symbol" column.
+    assert rows and rows[0]["symbol"] == "BTCUSDT"
+
+
 def test_duplicate_trade_guard(tmp_path, monkeypatch):
     path = tmp_path / "active.json"
     monkeypatch.setattr(trade_storage, "ACTIVE_TRADES_FILE", str(path))


### PR DESCRIPTION
## Summary
- ensure trade history CSV writes a header even when pre-existing file is empty
- add regression test for empty history file case

## Testing
- `pytest tests/test_trade_storage.py::test_log_trade_result_writes_header_if_file_empty -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b1b8e3fc832d9a8b1465c7a5d2b9