### PR TITLE
chore: update Groq model

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -89,7 +89,8 @@ def analyze_news_with_llm(events: List[Dict[str, str]]) -> Dict[str, str]:
     client = Groq(api_key=GROQ_API_KEY)
     try:
         chat_completion = client.chat.completions.create(
-            model="llama3-70b-8192",
+            # Switch to Groq's supported model
+            model="llama-3.1-70b-versatile",
             messages=[
                 {"role": "system", "content": "You are a crypto macro risk analyst."},
                 {"role": "user", "content": prompt},

--- a/groq_llm.py
+++ b/groq_llm.py
@@ -27,7 +27,8 @@ from log_utils import setup_logger
 
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions"
-MODEL = "llama3-70b-8192"
+# Updated default Groq model to a currently supported version
+MODEL = "llama-3.1-70b-versatile"
 HEADERS = {
     "Authorization": f"Bearer {GROQ_API_KEY}",
     "Content-Type": "application/json"

--- a/macro_sentiment.py
+++ b/macro_sentiment.py
@@ -35,7 +35,8 @@ Confidence: <0-10 score>
 
     try:
         response = client.chat.completions.create(
-            model="llama3-70b-8192",
+            # Use Groq's current supported model
+            model="llama-3.1-70b-versatile",
             messages=[
                 {"role": "system", "content": "You are a crypto macro market analyst."},
                 {"role": "user", "content": prompt}

--- a/narrative_builder.py
+++ b/narrative_builder.py
@@ -80,7 +80,8 @@ Write a short, confident explanation justifying the trade in plain English. End 
 
     try:
         response = client.chat.completions.create(
-            model="llama3-70b-8192",
+            # Updated to use Groq's current model
+            model="llama-3.1-70b-versatile",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.7,
             max_tokens=500,

--- a/narrator.py
+++ b/narrator.py
@@ -49,7 +49,8 @@ Trade Details:
 """
 
         response = client.chat.completions.create(
-            model="llama3-70b-8192",
+            # Updated to the latest Groq model
+            model="llama-3.1-70b-versatile",
             messages=[
                 {"role": "system", "content": "You are a professional crypto trading strategist."},
                 {"role": "user", "content": prompt}

--- a/news_filter.py
+++ b/news_filter.py
@@ -51,7 +51,8 @@ def analyze_news_with_llm(prompt):
     try:
         client = Groq(api_key=os.getenv("GROQ_API_KEY"))
         response = client.chat.completions.create(
-            model="llama3-70b-8192",
+            # Updated to Groq's latest supported model
+            model="llama-3.1-70b-versatile",
             messages=[{"role": "user", "content": prompt}]
         )
         reply = response.choices[0].message.content


### PR DESCRIPTION
## Summary
- switch Groq integrations to `llama-3.1-70b-versatile`
- align narrative, news, and sentiment modules with the new model

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8b9f4ff58832d8792dea9043ffa2d