### PR TITLE
Normalize trade timestamps and net PnL percentages

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -473,20 +473,20 @@ def render_live_tab() -> None:
         # Use quantity times price difference
         pnl_abs = (exits - entries) * sizes * direction_sign
         pnl_net = pnl_abs - fees - slippage
-        # Compute percentage based on notional when available
+        # Compute percentage based on net PnL and notional when available
         if "notional" in hist_df.columns:
             notional_series = pd.to_numeric(
                 hist_df["notional"], errors="coerce"
             ).replace(0, np.nan)
             pnl_pct = np.where(
                 notional_series.notnull(),
-                pnl_abs / notional_series * 100,
+                pnl_net / notional_series * 100,
                 0.0,
             )
         else:
             pnl_pct = np.where(
-                entries > 0,
-                pnl_abs / (entries * sizes) * 100,
+                (entries * sizes) != 0,
+                pnl_net / (entries * sizes) * 100,
                 0,
             )
         hist_df["PnL ($)"] = pnl_abs

--- a/tests/test_trade_dedup.py
+++ b/tests/test_trade_dedup.py
@@ -8,8 +8,8 @@ def test_deduplicate_history(tmp_path, monkeypatch):
             "trade_id": "1",
             "symbol": "BTCUSDT",
             "direction": "long",
-            "entry_time": "2024-01-01 00:00:00",
-            "exit_time": "2024-01-01 01:00:00",
+            "entry_time": "2024-01-01T00:00:00Z",
+            "exit_time": "2024-01-01T01:00:00Z",
             "entry": 100.0,
             "exit": 110.0,
             "size": 1.0,
@@ -22,8 +22,8 @@ def test_deduplicate_history(tmp_path, monkeypatch):
             "trade_id": "1",
             "symbol": "BTCUSDT",
             "direction": "long",
-            "entry_time": "2024-01-01 00:00:00",
-            "exit_time": "2024-01-01 02:00:00",
+            "entry_time": "2024-01-01T00:00:00Z",
+            "exit_time": "2024-01-01T02:00:00Z",
             "entry": 100.0,
             "exit": 120.0,
             "size": 1.0,
@@ -36,8 +36,8 @@ def test_deduplicate_history(tmp_path, monkeypatch):
             "trade_id": "1",
             "symbol": "BTCUSDT",
             "direction": "long",
-            "entry_time": "2024-01-01 00:00:00",
-            "exit_time": "2024-01-01 02:00:00",
+            "entry_time": "2024-01-01T00:00:00Z",
+            "exit_time": "2024-01-01T02:00:00Z",
             "entry": 100.0,
             "exit": 120.0,
             "size": 1.0,
@@ -56,4 +56,5 @@ def test_deduplicate_history(tmp_path, monkeypatch):
     assert len(result) == 2
     # net_pnl aggregates all partial exits
     assert set(result["net_pnl"].dropna()) == {30.0}
+    assert set(result["pnl_pct"].dropna()) == {30.0}
 

--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -39,6 +39,9 @@ def test_log_trade_result_extended_fields(tmp_path, monkeypatch):
     assert "volatility" in rows[0]
     assert "macro_indicator" in rows[0]
     assert "llm_error" in rows[0]
+    assert rows[0]["timestamp"].endswith("Z")
+    assert float(rows[0]["pnl"]) == 100.0
+    assert float(rows[0]["pnl_pct"]) == 10.0
 
 
 def test_log_trade_result_writes_header_if_file_empty(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- store trade timestamps in explicit UTC ISO-8601 format
- log net PnL and PnL% based on notional
- compute PnL% from net PnL in dashboard and history dedup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b95f418d00832da38c912cc58a07be