### PR TITLE
Resolve Groq model decommission error

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,28 @@ load_dotenv()
 
 import os
 
+
+# ---------------------------------------------------------------------------
+# Environment helpers
+# ---------------------------------------------------------------------------
 def get(key: str, default: str | None = None) -> str | None:
     """Retrieve an environment variable with an optional default."""
     return os.getenv(key, default)
+
+
+# Default Groq model and mapping for deprecated names
+DEFAULT_GROQ_MODEL = "llama-3.1-70b-versatile"
+_DEPRECATED_GROQ_MODELS = {
+    "llama3-70b-8192": DEFAULT_GROQ_MODEL,
+}
+
+
+def get_groq_model() -> str:
+    """Return a supported Groq model name.
+
+    If ``GROQ_MODEL`` is set to a deprecated model identifier, it is mapped to
+    the current default model so API calls do not fail with a 400 error.
+    """
+
+    model = os.getenv("GROQ_MODEL", DEFAULT_GROQ_MODEL)
+    return _DEPRECATED_GROQ_MODELS.get(model, model)

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -8,6 +8,7 @@ import aiohttp
 from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 from groq import Groq
+import config
 
 from log_utils import setup_logger
 
@@ -16,6 +17,7 @@ logger = setup_logger(__name__)
 
 NEWS_API_KEY = os.getenv("NEWS_API_KEY", "")
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
+GROQ_MODEL = config.get_groq_model()
 
 
 async def _fetch_rss(session: aiohttp.ClientSession, url: str, impact: str) -> List[Dict[str, str]]:
@@ -89,8 +91,7 @@ def analyze_news_with_llm(events: List[Dict[str, str]]) -> Dict[str, str]:
     client = Groq(api_key=GROQ_API_KEY)
     try:
         chat_completion = client.chat.completions.create(
-            # Switch to Groq's supported model
-            model="llama-3.1-70b-versatile",
+            model=GROQ_MODEL,
             messages=[
                 {"role": "system", "content": "You are a crypto macro risk analyst."},
                 {"role": "user", "content": prompt},

--- a/groq_llm.py
+++ b/groq_llm.py
@@ -23,12 +23,12 @@ import json
 import aiohttp
 import asyncio
 import time
+import config
 from log_utils import setup_logger
 
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions"
-# Updated default Groq model to a currently supported version
-MODEL = "llama-3.1-70b-versatile"
+MODEL = config.get_groq_model()
 HEADERS = {
     "Authorization": f"Bearer {GROQ_API_KEY}",
     "Content-Type": "application/json"

--- a/macro_sentiment.py
+++ b/macro_sentiment.py
@@ -6,6 +6,7 @@ from log_utils import setup_logger
 # Centralised configuration loader
 import config
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
+GROQ_MODEL = config.get_groq_model()
 client = Groq(api_key=GROQ_API_KEY)
 
 logger = setup_logger(__name__)
@@ -35,8 +36,7 @@ Confidence: <0-10 score>
 
     try:
         response = client.chat.completions.create(
-            # Use Groq's current supported model
-            model="llama-3.1-70b-versatile",
+            model=GROQ_MODEL,
             messages=[
                 {"role": "system", "content": "You are a crypto macro market analyst."},
                 {"role": "user", "content": prompt}

--- a/narrative_builder.py
+++ b/narrative_builder.py
@@ -19,11 +19,13 @@ from groq import Groq
 import os
 
 from dotenv import load_dotenv
+import config
 
 load_dotenv()
 
-# Retrieve API key from environment (unchanged from original)
+# Retrieve API key and model from environment
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
+GROQ_MODEL = config.get_groq_model()
 
 # Initialise the Groq client once
 client = Groq(api_key=GROQ_API_KEY)
@@ -80,8 +82,7 @@ Write a short, confident explanation justifying the trade in plain English. End 
 
     try:
         response = client.chat.completions.create(
-            # Updated to use Groq's current model
-            model="llama-3.1-70b-versatile",
+            model=GROQ_MODEL,
             messages=[{"role": "user", "content": prompt}],
             temperature=0.7,
             max_tokens=500,

--- a/narrator.py
+++ b/narrator.py
@@ -1,11 +1,13 @@
 import os
 from groq import Groq
 from dotenv import load_dotenv
+import config
 
 load_dotenv()
 
-# === Load Groq API Key ===
+# === Load Groq API Key and model ===
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
+GROQ_MODEL = config.get_groq_model()
 client = Groq(api_key=GROQ_API_KEY)
 
 
@@ -49,8 +51,7 @@ Trade Details:
 """
 
         response = client.chat.completions.create(
-            # Updated to the latest Groq model
-            model="llama-3.1-70b-versatile",
+            model=GROQ_MODEL,
             messages=[
                 {"role": "system", "content": "You are a professional crypto trading strategist."},
                 {"role": "user", "content": prompt}

--- a/news_filter.py
+++ b/news_filter.py
@@ -4,9 +4,11 @@ from groq import Groq
 import os
 from dotenv import load_dotenv
 from log_utils import setup_logger
+import config
 
 load_dotenv()
 logger = setup_logger(__name__)
+GROQ_MODEL = config.get_groq_model()
 
 
 def load_events(path="news_events.json"):
@@ -51,8 +53,7 @@ def analyze_news_with_llm(prompt):
     try:
         client = Groq(api_key=os.getenv("GROQ_API_KEY"))
         response = client.chat.completions.create(
-            # Updated to Groq's latest supported model
-            model="llama-3.1-70b-versatile",
+            model=GROQ_MODEL,
             messages=[{"role": "user", "content": prompt}]
         )
         reply = response.choices[0].message.content

--- a/sentiment.py
+++ b/sentiment.py
@@ -4,14 +4,14 @@ import re
 import requests
 from dotenv import load_dotenv
 from log_utils import setup_logger
+import config
 
 load_dotenv()
 
 # Groq API configuration
 GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
 GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
-# Default to Groq's latest supported model if not specified
-GROQ_MODEL = os.getenv("GROQ_MODEL", "llama-3.1-70b-versatile")
+GROQ_MODEL = config.get_groq_model()
 
 # Cache for latest macro sentiment
 latest_macro_sentiment = {"bias": "neutral", "confidence": 5.0, "summary": "No analysis yet."}


### PR DESCRIPTION
## Summary
- centralize Groq model selection and map deprecated names to `llama-3.1-70b-versatile`
- update narrative and sentiment helpers to use the centralized model

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9ffcf67d8832d88a5767af3ae4648