### PR TITLE
Scale trade size between $100 and $200 based on confidence

### DIFF
--- a/tests/test_trade_sizing.py
+++ b/tests/test_trade_sizing.py
@@ -1,0 +1,6 @@
+from agent import calculate_dynamic_trade_size
+
+
+def test_trade_size_bounds():
+    assert calculate_dynamic_trade_size(0, 0.0, 0) == 100.0
+    assert calculate_dynamic_trade_size(10, 1.0, 10) == 200.0


### PR DESCRIPTION
## Summary
- replace dynamic risk calculation with `calculate_dynamic_trade_size`
- size each trade in USD between $100-$200 after RL multiplier and store as `usd_size`
- add test covering trade size bounds

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68ba0d97bb34832d82e80aa3b5826dc5