### PR TITLE
Normalize trade history column names

### DIFF
--- a/tests/test_trade_history_columns.py
+++ b/tests/test_trade_history_columns.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import trade_storage
+
+def test_load_trade_history_df_normalises_columns(tmp_path, monkeypatch):
+    data = {
+        "EntryPrice": [100.0],
+        "ExitPrice": [110.0],
+        "Position_Size": [1.0],
+        "Trade_Outcome": ["tp1"],
+        "Entry_Timestamp": ["2024-01-01T00:00:00Z"],
+        "Exit_Timestamp": ["2024-01-01T01:00:00Z"],
+    }
+    df = pd.DataFrame(data)
+    path = tmp_path / "history.csv"
+    df.to_csv(path, index=False)
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(path))
+    result = trade_storage.load_trade_history_df()
+    assert not result.empty
+    assert {"entry", "exit", "size", "outcome", "entry_time", "exit_time"}.issubset(result.columns)


### PR DESCRIPTION
## Summary
- Normalize legacy trade history column names so the dashboard can load historical trades regardless of header changes
- Add regression test ensuring `load_trade_history_df` standardizes varied column names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab695b270832d9790d2a61d84e76c