### PR TITLE
Enforce minimum trade size of 100 USDT

### DIFF
--- a/tests/test_trade_sizing.py
+++ b/tests/test_trade_sizing.py
@@ -1,6 +1,10 @@
-from agent import calculate_dynamic_trade_size
+from agent import (
+    calculate_dynamic_trade_size,
+    MIN_TRADE_USD,
+    MAX_TRADE_USD,
+)
 
 
 def test_trade_size_bounds():
-    assert calculate_dynamic_trade_size(0, 0.0, 0) == 100.0
-    assert calculate_dynamic_trade_size(10, 1.0, 10) == 200.0
+    assert calculate_dynamic_trade_size(0, 0.0, 0) == MIN_TRADE_USD
+    assert calculate_dynamic_trade_size(10, 1.0, 10) == MAX_TRADE_USD


### PR DESCRIPTION
## Summary
- define configurable MIN_TRADE_USD and MAX_TRADE_USD constants
- clamp dynamic trade size calculations to stay within 100–200 USDT
- adjust test to reference new constants

## Testing
- `pytest tests/test_trade_sizing.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab8dfbd34832dab2f6e0352e8fd67