### PR TITLE
Handle empty PnL in histogram

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -641,9 +641,18 @@ def render_live_tab() -> None:
             )
         # Distribution of trade returns
         if "PnL (%)" in hist_df.columns:
-            hist_vals, bins = np.histogram(hist_df["PnL (%)"].astype(float), bins=20)
-            hist_chart_df = pd.DataFrame({"Return": bins[:-1], "Count": hist_vals})
-            st.bar_chart(hist_chart_df.set_index("Return"), use_container_width=True)
+            # Safely convert to numeric and drop missing/inf values before histogram
+            pnl_series = (
+                pd.to_numeric(hist_df["PnL (%)"], errors="coerce")
+                .replace([np.inf, -np.inf], np.nan)
+                .dropna()
+            )
+            if not pnl_series.empty:
+                hist_vals, bins = np.histogram(pnl_series, bins=20)
+                hist_chart_df = pd.DataFrame({"Return": bins[:-1], "Count": hist_vals})
+                st.bar_chart(
+                    hist_chart_df.set_index("Return"), use_container_width=True
+                )
         # Performance analytics by symbol and strategy
         if "PnL (net $)" in hist_df.columns:
             if "symbol" in hist_df.columns:


### PR DESCRIPTION
## Summary
- avoid histogram failure by dropping NaN/inf PnL values before plotting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bad5f0d9b8832dabc6b89f8d78316d