### PR TITLE
Add validation for trade history rows

### DIFF
--- a/tests/test_trade_history_validation.py
+++ b/tests/test_trade_history_validation.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import trade_storage
+import logging
+
+
+def test_load_trade_history_df_drops_invalid_rows(tmp_path, monkeypatch, caplog):
+    data = [
+        {
+            "symbol": "BTCUSDT",
+            "direction": "long",
+            "entry": 100.0,
+            "exit": 110.0,
+            "size": 1.0,
+            "outcome": "tp1",
+        },
+        {
+            "symbol": 12345,
+            "direction": "up",
+            "entry": 200.0,
+            "exit": 210.0,
+            "size": 1.0,
+            "outcome": "tp1",
+        },
+    ]
+    df = pd.DataFrame(data)
+    path = tmp_path / "history.csv"
+    df.to_csv(path, index=False)
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(path))
+    with caplog.at_level(logging.WARNING):
+        result = trade_storage.load_trade_history_df()
+    assert len(result) == 1
+    assert result.iloc[0]["symbol"] == "BTCUSDT"
+    assert "Dropped 1 malformed trade rows" in caplog.text


### PR DESCRIPTION
## Summary
- drop malformed rows with numeric symbols or invalid directions when loading trade history
- warn when malformed rows are removed
- add regression test for trade history validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb1c2789b0832da7ae38dc0a2e8b3e