### PR TITLE
Allow numeric symbols in trade history

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -910,9 +910,10 @@ def render_backtest_tab() -> None:
             )
 
 
-# Create tabs and render contents
-tab_live, tab_backtest = st.tabs(["Dashboard", "Backtest"])
-with tab_live:
-    render_live_tab()
-with tab_backtest:
-    render_backtest_tab()
+# Create tabs and render contents only when executed as a script
+if __name__ == "__main__":
+    tab_live, tab_backtest = st.tabs(["Dashboard", "Backtest"])
+    with tab_live:
+        render_live_tab()
+    with tab_backtest:
+        render_backtest_tab()

--- a/tests/test_trade_history_validation.py
+++ b/tests/test_trade_history_validation.py
@@ -14,6 +14,14 @@ def test_load_trade_history_df_drops_invalid_rows(tmp_path, monkeypatch, caplog)
             "outcome": "tp1",
         },
         {
+            "symbol": "1000PEPEUSDT",
+            "direction": "long",
+            "entry": 50.0,
+            "exit": 55.0,
+            "size": 1.0,
+            "outcome": "tp1",
+        },
+        {
             "symbol": 12345,
             "direction": "up",
             "entry": 200.0,
@@ -28,6 +36,6 @@ def test_load_trade_history_df_drops_invalid_rows(tmp_path, monkeypatch, caplog)
     monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(path))
     with caplog.at_level(logging.WARNING):
         result = trade_storage.load_trade_history_df()
-    assert len(result) == 1
-    assert result.iloc[0]["symbol"] == "BTCUSDT"
+    assert len(result) == 2
+    assert set(result["symbol"]) == {"BTCUSDT", "1000PEPEUSDT"}
     assert "Dropped 1 malformed trade rows" in caplog.text

--- a/trade_storage.py
+++ b/trade_storage.py
@@ -555,10 +555,12 @@ def load_trade_history_df() -> pd.DataFrame:
         # standardise column names to lowercase for downstream consumers
         df.columns = [c.lower() for c in df.columns]
         # Drop rows where symbol or direction look invalid to guard against
-        # misaligned numeric rows polluting the dashboard
+        # misaligned numeric rows polluting the dashboard.  Symbols may contain
+        # numbers (e.g., ``1000SHIBUSDT``) so we accept alphanumeric strings
+        # rather than only alphabetic ones.
         if {"symbol", "direction"}.issubset(df.columns):
             mask = (
-                df["symbol"].astype(str).str.isalpha()
+                df["symbol"].astype(str).str.match(r"^[A-Za-z0-9_]+$", na=False)
                 & df["direction"].astype(str).str.lower().isin(["long", "short"])
             )
             dropped = len(df) - int(mask.sum())


### PR DESCRIPTION
## Summary
- permit alphanumeric symbols when loading trade history so pairs like `1000PEPEUSDT` are displayed
- prevent dashboard UI from executing during imports
- add regression test for numeric symbol handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb233650d0832d918e77fddd502293