### PR TITLE
Relax trade history loader to handle legacy headers

### DIFF
--- a/tests/test_trade_history_columns.py
+++ b/tests/test_trade_history_columns.py
@@ -3,12 +3,12 @@ import trade_storage
 
 def test_load_trade_history_df_normalises_columns(tmp_path, monkeypatch):
     data = {
-        "EntryPrice": [100.0],
-        "ExitPrice": [110.0],
-        "Position_Size": [1.0],
-        "Trade_Outcome": ["tp1"],
-        "Entry_Timestamp": ["2024-01-01T00:00:00Z"],
-        "Exit_Timestamp": ["2024-01-01T01:00:00Z"],
+        "Entry Price": [100.0],
+        "Exit Price": [110.0],
+        "Position Size": [1.0],
+        "Trade Outcome": ["tp1"],
+        "Entry Timestamp": ["2024-01-01T00:00:00Z"],
+        "Exit Timestamp": ["2024-01-01T01:00:00Z"],
     }
     df = pd.DataFrame(data)
     path = tmp_path / "history.csv"

--- a/tests/test_trade_history_pnl_pct.py
+++ b/tests/test_trade_history_pnl_pct.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import pytest
+import trade_storage
+
+
+def test_load_trade_history_df_computes_pnl_pct(tmp_path, monkeypatch):
+    data = {
+        "symbol": ["BTCUSDT"],
+        "direction": ["long"],
+        "entry": [100.0],
+        "exit": [110.0],
+        "size": [1.0],
+        "outcome": ["tp1"],
+        "net pnl": [10.0],  # legacy header with space
+        "notional value": [100.0],
+        "exit timestamp": ["2024-01-01T01:00:00Z"],
+    }
+    df = pd.DataFrame(data)
+    path = tmp_path / "history.csv"
+    df.to_csv(path, index=False)
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(path))
+    result = trade_storage.load_trade_history_df()
+    assert pytest.approx(result.iloc[0]["pnl_pct"], rel=1e-6) == 10.0
+    assert pytest.approx(result.iloc[0]["PnL (%)"], rel=1e-6) == 10.0
+


### PR DESCRIPTION
## Summary
- soften `load_trade_history_df` header validation so legacy/space-separated names map to canonical fields
- parse timestamps with `errors='coerce'` and drop only rows without any valid time values
- compute missing `pnl_pct`/`PnL (%)` from `net_pnl` or `pnl` and `notional`
- add regression test for legacy PnL fields and update column normalisation test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb6bb37e14832d8beaca2c29670383