### PR TITLE
Ensure historical metrics use logged notional

### DIFF
--- a/tests/test_trade_history_notional_fallback.py
+++ b/tests/test_trade_history_notional_fallback.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import pytest
+import trade_storage
+
+
+def test_history_uses_size_as_notional(tmp_path, monkeypatch):
+    data = {
+        "symbol": ["BTCUSDT"],
+        "direction": ["long"],
+        "entry": [100.0],
+        "exit": [110.0],
+        "size": [100.0],  # already a notional amount
+        "outcome": ["tp1"],
+        "exit timestamp": ["2024-01-01T01:00:00Z"],
+    }
+    df = pd.DataFrame(data)
+    path = tmp_path / "history.csv"
+    df.to_csv(path, index=False)
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(path))
+    monkeypatch.setattr(trade_storage, "SIZE_AS_NOTIONAL", True)
+    result = trade_storage.load_trade_history_df()
+    row = result.iloc[0]
+    assert pytest.approx(row["notional"], rel=1e-6) == 100.0
+    assert pytest.approx(row["pnl_pct"], rel=1e-6) == 10.0
+
+
+def test_history_computes_notional_from_quantity(tmp_path, monkeypatch):
+    data = {
+        "symbol": ["BTCUSDT"],
+        "direction": ["long"],
+        "entry": [100.0],
+        "exit": [110.0],
+        "size": [1.0],  # quantity
+        "position_size": [1.0],
+        "outcome": ["tp1"],
+        "exit timestamp": ["2024-01-01T01:00:00Z"],
+    }
+    df = pd.DataFrame(data)
+    path = tmp_path / "history.csv"
+    df.to_csv(path, index=False)
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(path))
+    monkeypatch.setattr(trade_storage, "SIZE_AS_NOTIONAL", False)
+    result = trade_storage.load_trade_history_df()
+    row = result.iloc[0]
+    assert pytest.approx(row["notional"], rel=1e-6) == 100.0
+    assert pytest.approx(row["pnl_pct"], rel=1e-6) == 10.0


### PR DESCRIPTION
## Summary
- guard notional derivation in `load_trade_history_df` and history dedup to respect `SIZE_AS_NOTIONAL`
- update dashboard historical view to use logged notional and derive quantity correctly
- add tests covering notional fallback for both modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf7a3ac200832daa45c85d3b713c2f