### PR TITLE
chore: align header map prices and sizes

### DIFF
--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -18,8 +18,8 @@ HEADER_MAP = {
 
     # prices & sizes
     "EntryPrice": "entry_price", "ExitPrice": "exit_price",
-    "entry": "entry_price", "exit": "exit_price",   # <-- add these two
-    "Size": "size_quote", "size": "size_quote", "QuoteSize": "size_quote", "notional": "size_quote",
+    "entry": "entry_price", "exit": "exit_price",
+    "Size": "size_quote", "SizeQuote": "size_quote", "QuoteSize": "size_quote",
     "Qty": "size_base", "BaseSize": "size_base",
 
     # economics


### PR DESCRIPTION
## Summary
- standardize the header normalization map for entry/exit prices and trade sizes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c218631d3c832da50cb9739477e3aa