### PR TITLE
Aggregate partial trade exits into single rows

### DIFF
--- a/docs/trade_record_format.md
+++ b/docs/trade_record_format.md
@@ -20,6 +20,12 @@ Each row recorded by `trade_storage.log_trade_result` contains the following col
 | `slippage` | Slippage incurred on exit. |
 | `pnl` | Net profit or loss in quote currency after fees and slippage. |
 | `pnl_pct` | Profit/loss as a percentage of `notional`. |
+| `size_tp1` | Size closed at the TP1 partial exit. |
+| `notional_tp1` | Notional value closed at the TP1 partial exit. |
+| `pnl_tp1` | Profit or loss realised at the TP1 partial exit. |
+| `size_tp2` | Size closed at the TP2 partial exit. |
+| `notional_tp2` | Notional value closed at the TP2 partial exit. |
+| `pnl_tp2` | Profit or loss realised at the TP2 partial exit. |
 | `outcome` | Outcome code (see table below). |
 | `outcome_desc` | Human readable description of the outcome. |
 | `strategy` | Name of the strategy responsible for the trade. |
@@ -67,4 +73,4 @@ Partial exits are denoted with a `_partial` suffix. Manual closures may appear a
 trade_id,timestamp,symbol,direction,entry_time,exit_time,entry,exit,size,notional,fees,slippage,pnl,pnl_pct,outcome,outcome_desc,strategy,session,confidence,btc_dominance,fear_greed,sentiment_bias,sentiment_confidence,score,pattern,narrative,llm_decision,llm_confidence,llm_error,volatility,htf_trend,order_imbalance,macro_indicator
 ```
 
-A single trade may produce multiple rows if partial take-profits occur. The loader collapses these into one row using `_deduplicate_history` while retaining `tp1_partial`/`tp2_partial` flags.
+A single trade may produce multiple rows if partial take-profits occur. Rows are grouped by `trade_id` (falling back to `entry_time`, `symbol` and `strategy` when absent) and collapsed into one summary row by `_deduplicate_history`. PnL, size and notional values are summed for the whole trade, while per-stage fields such as `pnl_tp1`, `pnl_tp2`, `size_tp1`, `size_tp2`, `notional_tp1` and `notional_tp2` detail the contribution of each partial exit alongside the `tp1_partial`/`tp2_partial` flags.

--- a/tests/test_trade_dedup.py
+++ b/tests/test_trade_dedup.py
@@ -12,8 +12,8 @@ def test_deduplicate_history(tmp_path, monkeypatch):
             "exit_time": "2024-01-01T01:00:00Z",
             "entry": 100.0,
             "exit": 110.0,
-            "size": 100.0,
-            "position_size": 1.0,
+            "size": 50.0,
+            "position_size": 0.5,
             "strategy": "s1",
             "outcome": "tp1_partial",
             "fees": 0,
@@ -27,25 +27,25 @@ def test_deduplicate_history(tmp_path, monkeypatch):
             "exit_time": "2024-01-01T02:00:00Z",
             "entry": 100.0,
             "exit": 120.0,
-            "size": 100.0,
-            "position_size": 1.0,
+            "size": 50.0,
+            "position_size": 0.5,
             "strategy": "s1",
             "outcome": "tp2_partial",
             "fees": 0,
             "slippage": 0,
         },
         {
-            "trade_id": "1",
+            "trade_id": "2",
             "symbol": "BTCUSDT",
             "direction": "long",
             "entry_time": "2024-01-01T00:00:00Z",
-            "exit_time": "2024-01-01T02:00:00Z",
-            "entry": 100.0,
-            "exit": 120.0,
-            "size": 100.0,
+            "exit_time": "2024-01-01T03:00:00Z",
+            "entry": 200.0,
+            "exit": 210.0,
+            "size": 200.0,
             "position_size": 1.0,
             "strategy": "s1",
-            "outcome": "tp2_partial",
+            "outcome": "tp2",
             "fees": 0,
             "slippage": 0,
         },
@@ -54,12 +54,27 @@ def test_deduplicate_history(tmp_path, monkeypatch):
     hist_file = tmp_path / "completed.csv"
     df.to_csv(hist_file, index=False)
     monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(hist_file))
-    result = trade_storage.load_trade_history_df()
-    # partial exits collapsed into a single row
-    assert len(result) == 1
-    row = result.iloc[0]
-    assert bool(row["tp1_partial"])
-    assert bool(row["tp2_partial"])
-    assert row["pnl"] == 30.0
-    assert row["pnl_pct"] == 30.0
+    result = trade_storage.load_trade_history_df().sort_values("trade_id").reset_index(drop=True)
+
+    # trade 1 collapsed into a single row
+    t1 = result[result["trade_id"].astype(str) == "1"].iloc[0]
+    assert bool(t1["tp1_partial"])
+    assert bool(t1["tp2_partial"])
+    assert t1["pnl"] == 15.0
+    assert t1["pnl_tp1"] == 5.0
+    assert t1["pnl_tp2"] == 10.0
+    assert t1["notional"] == 100.0
+    assert t1["notional_tp1"] == 50.0
+    assert t1["notional_tp2"] == 50.0
+    assert t1["size"] == 100.0
+    assert t1["size_tp1"] == 0.5
+    assert t1["size_tp2"] == 0.5
+    assert t1["position_size"] == 1.0
+
+    # second trade remains separate
+    assert len(result) == 2
+    t2 = result[result["trade_id"].astype(str) == "2"].iloc[0]
+    assert t2["pnl"] == 10.0
+    assert not bool(t2["tp1_partial"])
+    assert not bool(t2["tp2_partial"])
 


### PR DESCRIPTION
## Summary
- group historical trades by `trade_id` to collapse partial exits into one row
- expose per-take-profit metrics (`pnl_tp1`, `size_tp1`, `notional_tp1`, etc.)
- document new fields and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ba2deed8832da51ae2d2be8cf842