### PR TITLE
Persist per-stage take profit fields in trade log

### DIFF
--- a/docs/trade_record_format.md
+++ b/docs/trade_record_format.md
@@ -70,7 +70,7 @@ Partial exits are denoted with a `_partial` suffix. Manual closures may appear a
 ## Example Header
 
 ```
-trade_id,timestamp,symbol,direction,entry_time,exit_time,entry,exit,size,notional,fees,slippage,pnl,pnl_pct,outcome,outcome_desc,strategy,session,confidence,btc_dominance,fear_greed,sentiment_bias,sentiment_confidence,score,pattern,narrative,llm_decision,llm_confidence,llm_error,volatility,htf_trend,order_imbalance,macro_indicator
+trade_id,timestamp,symbol,direction,entry_time,exit_time,entry,exit,size,notional,fees,slippage,pnl,pnl_pct,size_tp1,notional_tp1,pnl_tp1,size_tp2,notional_tp2,pnl_tp2,outcome,outcome_desc,strategy,session,confidence,btc_dominance,fear_greed,sentiment_bias,sentiment_confidence,score,pattern,narrative,llm_decision,llm_confidence,llm_error,volatility,htf_trend,order_imbalance,macro_indicator
 ```
 
 A single trade may produce multiple rows if partial take-profits occur. Rows are grouped by `trade_id` (falling back to `entry_time`, `symbol` and `strategy` when absent) and collapsed into one summary row by `_deduplicate_history`. PnL, size and notional values are summed for the whole trade, while per-stage fields such as `pnl_tp1`, `pnl_tp2`, `size_tp1`, `size_tp2`, `notional_tp1` and `notional_tp2` detail the contribution of each partial exit alongside the `tp1_partial`/`tp2_partial` flags.

--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -43,6 +43,34 @@ def test_log_trade_result_extended_fields(tmp_path, monkeypatch):
     assert rows[0]["timestamp"].endswith("Z")
     assert float(rows[0]["pnl"]) == 100.0
     assert float(rows[0]["pnl_pct"]) == 10.0
+    assert float(rows[0]["pnl_tp1"]) == 0.0
+    assert float(rows[0]["pnl_tp2"]) == 0.0
+    assert float(rows[0]["size_tp1"]) == 0.0
+    assert float(rows[0]["size_tp2"]) == 0.0
+    assert float(rows[0]["notional_tp1"]) == 0.0
+    assert float(rows[0]["notional_tp2"]) == 0.0
+
+
+def test_log_trade_result_partial_tp_fields(tmp_path, monkeypatch):
+    csv_path = tmp_path / "log.csv"
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(csv_path))
+    trade = {
+        "symbol": "ETHUSDT",
+        "direction": "long",
+        "entry": 1000,
+        "size": 500,
+        "position_size": 0.5,
+        "strategy": "test",
+        "session": "Asia",
+    }
+    trade_storage.log_trade_result(trade, outcome="tp1_partial", exit_price=1100)
+    with open(csv_path, newline="") as f:
+        row = next(csv.DictReader(f))
+    assert float(row["pnl"]) == 50.0
+    assert float(row["pnl_tp1"]) == 50.0
+    assert float(row["size_tp1"]) == 0.5
+    assert float(row["notional_tp1"]) == 500.0
+    assert float(row["pnl_tp2"]) == 0.0
 
 
 def test_log_trade_result_writes_header_if_file_empty(tmp_path, monkeypatch):

--- a/trade_storage.py
+++ b/trade_storage.py
@@ -78,6 +78,12 @@ TRADE_HISTORY_HEADERS = [
     "slippage",
     "pnl",
     "pnl_pct",
+    "size_tp1",
+    "notional_tp1",
+    "pnl_tp1",
+    "size_tp2",
+    "notional_tp2",
+    "pnl_tp2",
     "outcome",
     "outcome_desc",
     "strategy",
@@ -404,6 +410,12 @@ def log_trade_result(
         "slippage": slippage,
         "pnl": pnl_val,
         "pnl_pct": pnl_pct,
+        "size_tp1": 0.0,
+        "notional_tp1": 0.0,
+        "pnl_tp1": 0.0,
+        "size_tp2": 0.0,
+        "notional_tp2": 0.0,
+        "pnl_tp2": 0.0,
         "outcome": outcome,
         "outcome_desc": OUTCOME_DESCRIPTIONS.get(outcome, outcome),
         "strategy": trade.get("strategy", "unknown"),
@@ -426,7 +438,28 @@ def log_trade_result(
         "order_imbalance": trade.get("order_imbalance", 0),
         "macro_indicator": trade.get("macro_indicator", 0),
     }
-    float_cols = ["entry", "exit", "size", "notional", "fees", "confidence"]
+    if "tp1_partial" in outcome:
+        row["size_tp1"] = quantity
+        row["notional_tp1"] = notional or 0.0
+        row["pnl_tp1"] = pnl_val
+    if "tp2_partial" in outcome:
+        row["size_tp2"] = quantity
+        row["notional_tp2"] = notional or 0.0
+        row["pnl_tp2"] = pnl_val
+    float_cols = [
+        "entry",
+        "exit",
+        "size",
+        "notional",
+        "fees",
+        "confidence",
+        "size_tp1",
+        "notional_tp1",
+        "pnl_tp1",
+        "size_tp2",
+        "notional_tp2",
+        "pnl_tp2",
+    ]
     for col in float_cols:
         try:
             row[col] = float(row.get(col, 0))


### PR DESCRIPTION
## Summary
- Extend trade log headers and writer to include size, notional, and PnL for TP1 and TP2 stages
- Document new TP1/TP2 columns in trade record format
- Test persistence of per-stage fields for partial exits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4bf3b7e10832db0d11a41f6ad900c