### PR TITLE
feat: refine profit riding exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository implements the Spot AI Super Agent – a research bot for scanning the crypto market, evaluating signals and managing paper trades. The project now supports asynchronous price fetching, optional dashboard service and basic backtesting utilities.
 
+Profit‑riding exits now combine ADX, MACD and Keltner Channel signals and support optional trailing take‑profit levels to lock in gains while letting winners run.
+
 ## Setup
 
 ```bash


### PR DESCRIPTION
## Summary
- combine ADX, MACD and Keltner channel signals for profit-riding exits
- add optional trailing TP levels that take partial profits and keep moving target
- document enhanced profit-riding logic in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c2577608832d9040f4d2037e68f3