### PR TITLE
Trail stop loss during profit riding

### DIFF
--- a/tests/test_stop_loss_update.py
+++ b/tests/test_stop_loss_update.py
@@ -1,5 +1,7 @@
 import trade_manager
 import trade_utils
+import pandas as pd
+import pytest
 
 
 def test_update_stop_loss_calls_util(monkeypatch):
@@ -47,3 +49,68 @@ def test_update_stop_loss_order_places_and_cancels(monkeypatch):
     assert dummy.oco_kwargs['symbol'] == 'BTCUSDT'
     assert dummy.oco_kwargs['price'] == 30000.0
     assert dummy.oco_kwargs['stopPrice'] == 25000.0
+
+
+def test_profit_riding_trails_stop_loss(monkeypatch):
+    trade = {
+        'symbol': 'BTCUSDT',
+        'direction': 'long',
+        'entry': 100.0,
+        'position_size': 1.0,
+        'sl': 120.0,
+        'tp1': 110.0,
+        'tp2': 120.0,
+        'tp3': 130.0,
+        'status': {'tp1': True, 'tp2': True, 'tp3': True},
+        'profit_riding': True,
+        'trail_tp_pct': 0.05,
+        'next_trail_tp': 150.0,
+    }
+
+    def fake_load():
+        return [trade]
+
+    saved = {}
+
+    def fake_save(trades):
+        saved['trades'] = trades
+
+    def fake_price_data(symbol):
+        return pd.DataFrame({'close': [151.0], 'high': [151.0], 'low': [151.0]})
+
+    def fake_commission(symbol, quantity, maker):
+        return 0.0
+
+    def fake_slippage(price, direction):
+        return price
+
+    def fake_calc_indicators(price_data):
+        return {'adx': 25, 'macd': 0, 'macd_signal': 0, 'kc_lower': 0, 'atr': 1}
+
+    def fake_macro():
+        return {'bias': 'neutral', 'confidence': 0}
+
+    sl_calls = {}
+
+    def fake_update_sl(tr, new_sl):
+        sl_calls['new_sl'] = new_sl
+        tr['sl'] = new_sl
+
+    monkeypatch.setattr(trade_manager, 'load_active_trades', fake_load)
+    monkeypatch.setattr(trade_manager, 'save_active_trades', fake_save)
+    monkeypatch.setattr(trade_manager, 'get_price_data', fake_price_data)
+    monkeypatch.setattr(trade_manager, 'estimate_commission', fake_commission)
+    monkeypatch.setattr(trade_manager, 'simulate_slippage', fake_slippage)
+    monkeypatch.setattr(trade_manager, 'calculate_indicators', fake_calc_indicators)
+    monkeypatch.setattr(trade_manager, 'analyze_macro_sentiment', fake_macro)
+    monkeypatch.setattr(trade_manager, 'log_trade_result', lambda *args, **kwargs: None)
+    monkeypatch.setattr(trade_manager, '_update_stop_loss', fake_update_sl)
+    monkeypatch.setattr(trade_manager, '_update_rl', lambda *args, **kwargs: None)
+    monkeypatch.setattr(trade_manager, 'send_email', lambda *args, **kwargs: None)
+
+    trade_manager.manage_trades()
+
+    assert sl_calls['new_sl'] == pytest.approx(150.0)
+    saved_trade = saved['trades'][0]
+    assert saved_trade['sl'] == pytest.approx(150.0)
+    assert saved_trade['next_trail_tp'] == pytest.approx(150.0 * 1.05)

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -473,6 +473,9 @@ def manage_trades() -> None:
                             f"✅ TP Trail: {symbol}",
                             f"{partial_trade}\n\n Narrative:\n{trade.get('narrative', 'N/A')}",
                         )
+                        new_sl = max(trade.get('sl', 0), next_tp)
+                        _update_stop_loss(trade, new_sl)
+                        logger.info("%s TP Trail: SL moved to %s", symbol, new_sl)
                         remaining_qty = qty - sell_qty
                         trade['position_size'] = remaining_qty
                         trade['size'] = remaining_qty * entry


### PR DESCRIPTION
## Summary
- Advance stop loss to the latest trailing take-profit when profit riding continues
- Test that profit riding updates the stop loss accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4c48633ec832d96b6e24438854a3a