### PR TITLE
Add win flag based on trade PnL

### DIFF
--- a/docs/trade_record_format.md
+++ b/docs/trade_record_format.md
@@ -20,6 +20,7 @@ Each row recorded by `trade_storage.log_trade_result` contains the following col
 | `slippage` | Slippage incurred on exit. |
 | `pnl` | Net profit or loss in quote currency after fees and slippage. |
 | `pnl_pct` | Profit/loss as a percentage of `notional`. |
+| `win` | `true` if `pnl` is positive, else `false`. |
 | `size_tp1` | Size closed at the TP1 partial exit. |
 | `notional_tp1` | Notional value closed at the TP1 partial exit. |
 | `pnl_tp1` | Profit or loss realised at the TP1 partial exit. |
@@ -74,7 +75,7 @@ Partial exits are denoted with a `_partial` suffix. Manual closures may appear a
 ## Example Header
 
 ```
-trade_id,timestamp,symbol,direction,entry_time,exit_time,entry,exit,size,notional,fees,slippage,pnl,pnl_pct,size_tp1,notional_tp1,pnl_tp1,size_tp2,notional_tp2,pnl_tp2,outcome,outcome_desc,strategy,session,confidence,btc_dominance,fear_greed,sentiment_bias,sentiment_confidence,score,pattern,narrative,llm_decision,llm_confidence,llm_error,volatility,htf_trend,order_imbalance,macro_indicator
+trade_id,timestamp,symbol,direction,entry_time,exit_time,entry,exit,size,notional,fees,slippage,pnl,pnl_pct,win,size_tp1,notional_tp1,pnl_tp1,size_tp2,notional_tp2,pnl_tp2,outcome,outcome_desc,strategy,session,confidence,btc_dominance,fear_greed,sentiment_bias,sentiment_confidence,score,pattern,narrative,llm_decision,llm_confidence,llm_error,volatility,htf_trend,order_imbalance,macro_indicator
 ```
 
 A single trade may produce multiple rows if partial take-profits occur. Rows are grouped by `trade_id` (falling back to `entry_time`, `symbol` and `strategy` when absent) and collapsed into one summary row by `_deduplicate_history`. PnL, size and notional values are summed for the whole trade, while per-stage fields such as `pnl_tp1`, `pnl_tp2`, `size_tp1`, `size_tp2`, `notional_tp1` and `notional_tp2` detail the contribution of each partial exit alongside the `tp1_partial`/`tp2_partial` flags.

--- a/tests/test_trade_history_pnl_pct.py
+++ b/tests/test_trade_history_pnl_pct.py
@@ -23,4 +23,5 @@ def test_load_trade_history_df_computes_pnl_pct(tmp_path, monkeypatch):
     result = trade_storage.load_trade_history_df()
     assert pytest.approx(result.iloc[0]["pnl_pct"], rel=1e-6) == 10.0
     assert pytest.approx(result.iloc[0]["PnL (%)"], rel=1e-6) == 10.0
+    assert result.iloc[0]["win"]
 

--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -49,6 +49,7 @@ def test_log_trade_result_extended_fields(tmp_path, monkeypatch):
     assert float(rows[0]["size_tp2"]) == 0.0
     assert float(rows[0]["notional_tp1"]) == 0.0
     assert float(rows[0]["notional_tp2"]) == 0.0
+    assert rows[0]["win"] == "True"
 
 
 def test_log_trade_result_partial_tp_fields(tmp_path, monkeypatch):
@@ -71,6 +72,25 @@ def test_log_trade_result_partial_tp_fields(tmp_path, monkeypatch):
     assert float(row["size_tp1"]) == 0.5
     assert float(row["notional_tp1"]) == 500.0
     assert float(row["pnl_tp2"]) == 0.0
+    assert row["win"] == "True"
+
+
+def test_win_flag_negative_pnl(tmp_path, monkeypatch):
+    csv_path = tmp_path / "log.csv"
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(csv_path))
+    trade = {
+        "symbol": "ETHUSDT",
+        "direction": "long",
+        "entry": 1000,
+        "size": 1000,
+        "position_size": 1,
+        "strategy": "test",
+        "session": "Asia",
+    }
+    trade_storage.log_trade_result(trade, outcome="sl", exit_price=900)
+    with open(csv_path, newline="") as f:
+        row = next(csv.DictReader(f))
+    assert row["win"] == "False"
 
 
 def test_log_trade_result_writes_header_if_file_empty(tmp_path, monkeypatch):

--- a/trade_storage.py
+++ b/trade_storage.py
@@ -78,6 +78,7 @@ TRADE_HISTORY_HEADERS = [
     "slippage",
     "pnl",
     "pnl_pct",
+    "win",
     "size_tp1",
     "notional_tp1",
     "pnl_tp1",
@@ -410,6 +411,7 @@ def log_trade_result(
         "slippage": slippage,
         "pnl": pnl_val,
         "pnl_pct": pnl_pct,
+        "win": pnl_val > 0,
         "size_tp1": 0.0,
         "notional_tp1": 0.0,
         "pnl_tp1": 0.0,
@@ -813,6 +815,14 @@ def load_trade_history_df() -> pd.DataFrame:
     df["pnl_pct"] = pd.to_numeric(df.get("pnl_pct"), errors="coerce")
     if "pnl_pct" in df.columns:
         df["PnL (%)"] = df["pnl_pct"]
+
+    # ------------------------------------------------------------------
+    # Determine win/loss classification
+    # ------------------------------------------------------------------
+    if "win" in df.columns:
+        df["win"] = df["win"].astype(str).str.lower().isin(["true", "1", "yes", "y"])
+    elif "pnl" in df.columns:
+        df["win"] = pd.to_numeric(df["pnl"], errors="coerce") > 0
 
     # ------------------------------------------------------------------
     # Ensure human readable outcome descriptions


### PR DESCRIPTION
## Summary
- add `win` column to trade history to classify trades by net PnL
- compute win/loss status when logging trades and when loading history
- document new trade record field

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4c5d4d7b0832d8eba0d3ae50e3a6b