### PR TITLE
Use current Groq model

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,9 +18,12 @@ def get(key: str, default: str | None = None) -> str | None:
 
 
 # Default Groq model and mapping for deprecated names
-DEFAULT_GROQ_MODEL = "llama-3.1-70b-versatile"
+# ``llama-3.1-70b-versatile`` has been decommissioned; use a currently
+# available model instead.
+DEFAULT_GROQ_MODEL = "llama-3.1-70b"
 _DEPRECATED_GROQ_MODELS = {
     "llama3-70b-8192": DEFAULT_GROQ_MODEL,
+    "llama-3.1-70b-versatile": DEFAULT_GROQ_MODEL,
 }
 
 

--- a/tests/test_groq_model_mapping.py
+++ b/tests/test_groq_model_mapping.py
@@ -1,0 +1,28 @@
+import importlib
+import config
+
+
+def reload_config():
+    importlib.reload(config)
+
+
+def test_default_model(monkeypatch):
+    monkeypatch.delenv("GROQ_MODEL", raising=False)
+    reload_config()
+    assert config.get_groq_model() == "llama-3.1-70b"
+
+
+def test_deprecated_model(monkeypatch):
+    monkeypatch.setenv("GROQ_MODEL", "llama-3.1-70b-versatile")
+    reload_config()
+    assert config.get_groq_model() == "llama-3.1-70b"
+    monkeypatch.delenv("GROQ_MODEL", raising=False)
+    reload_config()
+
+
+def test_custom_model(monkeypatch):
+    monkeypatch.setenv("GROQ_MODEL", "custom-model")
+    reload_config()
+    assert config.get_groq_model() == "custom-model"
+    monkeypatch.delenv("GROQ_MODEL", raising=False)
+    reload_config()


### PR DESCRIPTION
## Summary
- replace decommissioned `llama-3.1-70b-versatile` with `llama-3.1-70b`
- map deprecated model names to the new default to avoid 400 errors
- add tests verifying `GROQ_MODEL` environment mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bf02eaf0832d838e4110a413f5b3