### PR TITLE
Refresh Groq model lookup to avoid retired names

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -17,7 +17,6 @@ logger = setup_logger(__name__)
 
 NEWS_API_KEY = os.getenv("NEWS_API_KEY", "")
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
-GROQ_MODEL = config.get_groq_model()
 
 
 async def _fetch_rss(session: aiohttp.ClientSession, url: str, impact: str) -> List[Dict[str, str]]:
@@ -91,7 +90,7 @@ def analyze_news_with_llm(events: List[Dict[str, str]]) -> Dict[str, str]:
     client = Groq(api_key=GROQ_API_KEY)
     try:
         chat_completion = client.chat.completions.create(
-            model=GROQ_MODEL,
+            model=config.get_groq_model(),
             messages=[
                 {"role": "system", "content": "You are a crypto macro risk analyst."},
                 {"role": "user", "content": prompt},

--- a/groq_llm.py
+++ b/groq_llm.py
@@ -28,7 +28,6 @@ from log_utils import setup_logger
 
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions"
-MODEL = config.get_groq_model()
 HEADERS = {
     "Authorization": f"Bearer {GROQ_API_KEY}",
     "Content-Type": "application/json"
@@ -71,8 +70,9 @@ def get_llm_judgment(prompt: str, temperature: float = 0.4, max_tokens: int = 50
             + " decision (Yes or No), confidence (0 to 10 as a number), reason (a short explanation),"
             + " and thesis (2-3 sentence summary)."
         )
+        model = config.get_groq_model()
         data = {
-            "model": MODEL,
+            "model": model,
             "messages": [
                 {"role": "system", "content": "You are a highly experienced crypto trader assistant. Always respond in JSON."},
                 {"role": "user", "content": user_prompt}
@@ -116,8 +116,9 @@ async def async_get_llm_judgment(prompt: str, temperature: float = 0.4, max_toke
             + " decision (Yes or No), confidence (0 to 10 as a number), reason (a short explanation),"
             + " and thesis (2-3 sentence summary)."
         )
+        model = config.get_groq_model()
         data = {
-            "model": MODEL,
+            "model": model,
             "messages": [
                 {"role": "system", "content": "You are a highly experienced crypto trader assistant. Always respond in JSON."},
                 {"role": "user", "content": user_prompt}

--- a/macro_sentiment.py
+++ b/macro_sentiment.py
@@ -6,7 +6,6 @@ from log_utils import setup_logger
 # Centralised configuration loader
 import config
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
-GROQ_MODEL = config.get_groq_model()
 client = Groq(api_key=GROQ_API_KEY)
 
 logger = setup_logger(__name__)
@@ -36,7 +35,7 @@ Confidence: <0-10 score>
 
     try:
         response = client.chat.completions.create(
-            model=GROQ_MODEL,
+            model=config.get_groq_model(),
             messages=[
                 {"role": "system", "content": "You are a crypto macro market analyst."},
                 {"role": "user", "content": prompt}

--- a/narrative_builder.py
+++ b/narrative_builder.py
@@ -23,11 +23,8 @@ import config
 
 load_dotenv()
 
-# Retrieve API key and model from environment
+# Retrieve API key from environment and initialise the client once
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
-GROQ_MODEL = config.get_groq_model()
-
-# Initialise the Groq client once
 client = Groq(api_key=GROQ_API_KEY)
 
 
@@ -82,7 +79,7 @@ Write a short, confident explanation justifying the trade in plain English. End 
 
     try:
         response = client.chat.completions.create(
-            model=GROQ_MODEL,
+            model=config.get_groq_model(),
             messages=[{"role": "user", "content": prompt}],
             temperature=0.7,
             max_tokens=500,

--- a/narrator.py
+++ b/narrator.py
@@ -5,9 +5,8 @@ import config
 
 load_dotenv()
 
-# === Load Groq API Key and model ===
+# === Load Groq API Key ===
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
-GROQ_MODEL = config.get_groq_model()
 client = Groq(api_key=GROQ_API_KEY)
 
 
@@ -51,7 +50,7 @@ Trade Details:
 """
 
         response = client.chat.completions.create(
-            model=GROQ_MODEL,
+            model=config.get_groq_model(),
             messages=[
                 {"role": "system", "content": "You are a professional crypto trading strategist."},
                 {"role": "user", "content": prompt}

--- a/news_filter.py
+++ b/news_filter.py
@@ -8,7 +8,6 @@ import config
 
 load_dotenv()
 logger = setup_logger(__name__)
-GROQ_MODEL = config.get_groq_model()
 
 
 def load_events(path="news_events.json"):
@@ -53,7 +52,7 @@ def analyze_news_with_llm(prompt):
     try:
         client = Groq(api_key=os.getenv("GROQ_API_KEY"))
         response = client.chat.completions.create(
-            model=GROQ_MODEL,
+            model=config.get_groq_model(),
             messages=[{"role": "user", "content": prompt}]
         )
         reply = response.choices[0].message.content

--- a/sentiment.py
+++ b/sentiment.py
@@ -11,7 +11,6 @@ load_dotenv()
 # Groq API configuration
 GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
 GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
-GROQ_MODEL = config.get_groq_model()
 
 # Cache for latest macro sentiment
 latest_macro_sentiment = {"bias": "neutral", "confidence": 5.0, "summary": "No analysis yet."}
@@ -39,7 +38,7 @@ def analyze_macro_news(news_text: str) -> dict:
         {"role": "user", "content": prompt + "\nNews Headlines:\n" + news_text}
     ]
     payload = {
-        "model": GROQ_MODEL,
+        "model": config.get_groq_model(),
         "messages": messages,
         "temperature": 0.2,
         "max_tokens": 200

--- a/tests/test_dynamic_groq_model.py
+++ b/tests/test_dynamic_groq_model.py
@@ -1,0 +1,23 @@
+import importlib
+import types
+
+
+def test_llm_uses_mapped_model(monkeypatch):
+    monkeypatch.setenv("GROQ_MODEL", "llama-3.1-70b-versatile")
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    import groq_llm
+    importlib.reload(groq_llm)
+
+    captured = {}
+
+    def fake_post(url, headers, json):
+        captured["model"] = json["model"]
+        class Resp:
+            status_code = 200
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+        return Resp()
+
+    monkeypatch.setattr(groq_llm.requests, "post", fake_post)
+    groq_llm.get_llm_judgment("test prompt")
+    assert captured["model"] == "llama-3.1-70b"


### PR DESCRIPTION
## Summary
- Resolve the Groq model dynamically in every LLM helper so deprecated model names are never used
- Add regression test to ensure `llama-3.1-70b-versatile` is remapped to the current model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5de4b814c832d9c9cf0b1d8afa43a