### PR TITLE
Normalize merge keys in weight optimizer

### DIFF
--- a/weight_optimizer.py
+++ b/weight_optimizer.py
@@ -19,13 +19,16 @@ def optimize_indicator_weights(base_weights: dict, lookback: int = 200) -> dict:
     if not (os.path.exists(SIGNAL_LOG_FILE) and os.path.exists(TRADE_HISTORY_FILE)):
         return base_weights
     try:
-        # Ensure merge keys have consistent dtypes
-        signals = pd.read_csv(
-            SIGNAL_LOG_FILE, dtype={"timestamp": str, "symbol": str}
-        ).tail(lookback)
-        trades = pd.read_csv(
-            TRADE_HISTORY_FILE, dtype={"timestamp": str, "symbol": str}
-        ).tail(lookback)
+        signals = pd.read_csv(SIGNAL_LOG_FILE).tail(lookback)
+        trades = pd.read_csv(TRADE_HISTORY_FILE).tail(lookback)
+
+        # Normalize keys consistently on both frames
+        for df in (signals, trades):
+            if "symbol" in df.columns:
+                df["symbol"] = df["symbol"].astype(str).str.strip().str.upper()
+            if "timestamp" in df.columns:
+                df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+
         merged = pd.merge(
             signals,
             trades[["timestamp", "symbol", "outcome"]],


### PR DESCRIPTION
## Summary
- Ensure signal and trade logs normalize `symbol` and `timestamp` columns before merging
- Merge on consistently typed keys to avoid dtype mismatch errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c719d3b5dc832da55f9b47dee2da90