### PR TITLE
Improve trade history parsing for narrative fields

### DIFF
--- a/tests/test_trade_history_narrative.py
+++ b/tests/test_trade_history_narrative.py
@@ -1,0 +1,36 @@
+import csv
+import pandas as pd
+import trade_storage
+
+def test_load_trade_history_df_handles_narrative(tmp_path, monkeypatch):
+    # Craft a CSV row with a narrative containing commas, braces and quotes
+    row = {
+        "trade_id": "1",
+        "timestamp": "2024-06-01T00:00:00Z",
+        "symbol": "BTCUSDT",
+        "direction": "long",
+        "entry_time": "2024-06-01T00:00:00Z",
+        "exit_time": "2024-06-01T01:00:00Z",
+        "entry": 100,
+        "exit": 110,
+        "size": 1,
+        "notional": 100,
+        "fees": 0,
+        "slippage": 0,
+        "pnl": 10,
+        "pnl_pct": 10,
+        "win": True,
+        "outcome": "tp1",
+        "strategy": "pattern1",
+        "session": "us",
+        "narrative": 'Error: something, details {"foo": 1}',
+    }
+    path = tmp_path / "history.csv"
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=trade_storage.TRADE_HISTORY_HEADERS)
+        writer.writeheader()
+        writer.writerow(row)
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(path))
+    df = trade_storage.load_trade_history_df()
+    assert not df.empty
+    assert df.loc[0, "symbol"] == "BTCUSDT"


### PR DESCRIPTION
## Summary
- make trade history loading resilient to long narrative text by using Python CSV parser and fallback to DictReader
- add regression test covering narrative fields with commas and quotes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas', 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68c7fac7beec832db9fd2829cca40f9f