### PR TITLE
Fix dashboard history by loading legacy trade logs

### DIFF
--- a/tests/test_trade_history_fallback.py
+++ b/tests/test_trade_history_fallback.py
@@ -1,0 +1,34 @@
+import importlib
+
+import trade_storage
+
+
+def test_load_history_uses_legacy_file_when_primary_empty(monkeypatch, tmp_path):
+    primary = tmp_path / "primary.csv"
+    legacy = tmp_path / "legacy.csv"
+    primary.write_text("")
+    legacy.write_text(
+        "trade_id,timestamp,symbol,entry,exit,size,direction,outcome,pnl\n"
+        "1,2024-01-01T00:00:00Z,BTCUSDT,100,110,1,long,tp1,10\n"
+    )
+
+    monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(primary))
+    monkeypatch.setattr(trade_storage, "_LEGACY_HISTORY_FILES", [str(legacy)])
+    monkeypatch.setattr(trade_storage, "_HISTORY_ENV_OVERRIDE", False)
+
+    df = trade_storage.load_trade_history_df()
+    assert not df.empty
+    assert "BTCUSDT" in df["symbol"].astype(str).tolist()
+
+
+def test_completed_trades_env_alias(monkeypatch, tmp_path):
+    alias_file = tmp_path / "alias.csv"
+    alias_file.write_text("")
+
+    with monkeypatch.context() as m:
+        m.delenv("TRADE_HISTORY_FILE", raising=False)
+        m.setenv("COMPLETED_TRADES_FILE", str(alias_file))
+        importlib.reload(trade_storage)
+        assert trade_storage.TRADE_HISTORY_FILE == str(alias_file)
+
+    importlib.reload(trade_storage)

--- a/tests/test_trade_paths.py
+++ b/tests/test_trade_paths.py
@@ -22,10 +22,11 @@ def test_trade_paths(monkeypatch, tmp_path):
     monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(completed_path))
     monkeypatch.setattr(trade_storage.os.path, "exists", lambda p: True)
     monkeypatch.setattr(trade_storage.os.path, "getsize", lambda p: 1)
-    captured = {}
+    captured = {"paths": []}
     def fake_read_csv(path, *args, **kwargs):
-        captured["path"] = path
+        captured["paths"].append(path)
         return pd.DataFrame()
     monkeypatch.setattr(trade_storage.pd, "read_csv", fake_read_csv)
     trade_storage.load_trade_history_df()
-    assert captured["path"] == str(completed_path)
+    assert captured["paths"]
+    assert captured["paths"][0] == str(completed_path)


### PR DESCRIPTION
## Summary
- honour the legacy `COMPLETED_TRADES_FILE` environment variable and gather trade history from both the configured CSV and any legacy files so the dashboard continues to show older trades
- add a tolerant CSV reader helper used by `load_trade_history_df` to combine data sources without tripping on malformed rows
- extend the regression tests to cover the fallback behaviour and environment override detection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a569aef4832d9a11de2f684fe06b