### PR TITLE
Avoid duplicate historical tables in dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -543,7 +543,15 @@ def render_live_tab() -> None:
     if hist.empty:
         st.info("No completed trades logged yet.")
     else:
-        st.dataframe(hist.tail(20), use_container_width=True)
+        # Only surface the raw dataframe on demand so we don't present two
+        # different historical tables back-to-back in the UI.  The styled
+        # view further below remains the primary presentation.
+        latest_count = min(len(hist), 20)
+        if latest_count:
+            with st.expander(
+                f"View latest {latest_count} trade(s) in raw format", expanded=False
+            ):
+                st.dataframe(hist.tail(latest_count), use_container_width=True)
         hist_df = hist.copy()
         entry_col = next((c for c in ("entry", "entry_price") if c in hist_df.columns), None)
         exit_col = next((c for c in ("exit", "exit_price") if c in hist_df.columns), None)


### PR DESCRIPTION
## Summary
- hide the raw historical trade dataframe behind an expander so it no longer renders alongside the styled table
- keep the enhanced styled view as the primary historical display to avoid duplicate sections in the dashboard

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cf0c6abb74832d97c2a3d138368599