### PR TITLE
Improve Groq model resiliency

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 from groq import Groq
 import config
+from groq_safe import safe_chat_completion
 
 from log_utils import setup_logger
 
@@ -89,7 +90,8 @@ def analyze_news_with_llm(events: List[Dict[str, str]]) -> Dict[str, str]:
     prompt = build_news_prompt(events)
     client = Groq(api_key=GROQ_API_KEY)
     try:
-        chat_completion = client.chat.completions.create(
+        chat_completion = safe_chat_completion(
+            client,
             model=config.get_groq_model(),
             messages=[
                 {"role": "system", "content": "You are a crypto macro risk analyst."},

--- a/groq_safe.py
+++ b/groq_safe.py
@@ -1,0 +1,108 @@
+"""Utility helpers for resilient Groq LLM calls.
+
+This module centralises common logic for interacting with the Groq API.  It
+provides helpers that detect when a requested model has been decommissioned and
+automatically fall back to the supported default.  The logic is shared across
+both the high-level ``Groq`` SDK usage (``safe_chat_completion``) and the raw
+HTTP clients used elsewhere in the codebase.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import config
+from log_utils import setup_logger
+
+logger = setup_logger(__name__)
+
+_DECOMMISSIONED_HINTS = (
+    "model_decommissioned",
+    "has been decommissioned",
+    "is no longer supported",
+    "has been deprecated",
+    "model has been retired",
+)
+
+
+def _normalise_text(text: str | None) -> str:
+    """Return a case-insensitive representation of ``text``."""
+
+    if not text:
+        return ""
+    return str(text).lower()
+
+
+def _extract_error_parts(error: Any) -> tuple[str, str | None]:
+    """Extract a human readable message and error code from ``error``."""
+
+    if isinstance(error, Mapping):
+        inner = error.get("error")
+        if isinstance(inner, Mapping):
+            message = inner.get("message", "")
+            code = inner.get("code")
+            return str(message or ""), str(code) if code is not None else None
+        message = error.get("message", "")
+        code = error.get("code")
+        return str(message or ""), str(code) if code is not None else None
+    return str(error or ""), None
+
+
+def describe_error(error: Any) -> str:
+    """Return a compact description of ``error`` suitable for logging."""
+
+    message, code = _extract_error_parts(error)
+    if code and message:
+        return f"{code}: {message}"
+    if code:
+        return str(code)
+    return message
+
+
+def is_model_decommissioned_error(error: Any) -> bool:
+    """Return ``True`` if ``error`` indicates the requested model is retired."""
+
+    message, code = _extract_error_parts(error)
+    if code and code == "model_decommissioned":
+        return True
+    lowered = _normalise_text(message)
+    return any(hint in lowered for hint in _DECOMMISSIONED_HINTS)
+
+
+def safe_chat_completion(client, *, messages: list[dict[str, Any]], model: str | None = None, **kwargs: Any):
+    """Invoke ``client.chat.completions.create`` with automatic model fallback."""
+
+    requested_model = (model or config.get_groq_model()).strip()
+    if not requested_model:
+        requested_model = config.DEFAULT_GROQ_MODEL
+
+    try:
+        return client.chat.completions.create(
+            model=requested_model,
+            messages=messages,
+            **kwargs,
+        )
+    except Exception as err:  # pragma: no cover - SDK specific exception types
+        fallback_model = config.DEFAULT_GROQ_MODEL
+        if fallback_model != requested_model and is_model_decommissioned_error(err):
+            logger.warning(
+                "Groq model %s unavailable (%s). Retrying with fallback model %s.",
+                requested_model,
+                describe_error(err),
+                fallback_model,
+            )
+            return client.chat.completions.create(
+                model=fallback_model,
+                messages=messages,
+                **kwargs,
+            )
+        raise
+
+
+def extract_error_payload(response: Any) -> Any:
+    """Best-effort extraction of an error payload from ``response``."""
+
+    try:
+        return response.json()
+    except Exception:  # pragma: no cover - requests/aiohttp differences
+        return getattr(response, "text", "")

--- a/macro_sentiment.py
+++ b/macro_sentiment.py
@@ -5,6 +5,7 @@ from log_utils import setup_logger
 
 # Centralised configuration loader
 import config
+from groq_safe import safe_chat_completion
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 client = Groq(api_key=GROQ_API_KEY)
 
@@ -34,12 +35,13 @@ Confidence: <0-10 score>
 """
 
     try:
-        response = client.chat.completions.create(
+        response = safe_chat_completion(
+            client,
             model=config.get_groq_model(),
             messages=[
                 {"role": "system", "content": "You are a crypto macro market analyst."},
                 {"role": "user", "content": prompt}
-            ]
+            ],
         )
 
         result = response.choices[0].message.content.strip()

--- a/narrative_builder.py
+++ b/narrative_builder.py
@@ -20,6 +20,7 @@ import os
 
 from dotenv import load_dotenv
 import config
+from groq_safe import safe_chat_completion
 
 load_dotenv()
 
@@ -78,7 +79,8 @@ Write a short, confident explanation justifying the trade in plain English. End 
 """
 
     try:
-        response = client.chat.completions.create(
+        response = safe_chat_completion(
+            client,
             model=config.get_groq_model(),
             messages=[{"role": "user", "content": prompt}],
             temperature=0.7,

--- a/narrator.py
+++ b/narrator.py
@@ -2,6 +2,7 @@ import os
 from groq import Groq
 from dotenv import load_dotenv
 import config
+from groq_safe import safe_chat_completion
 
 load_dotenv()
 
@@ -49,12 +50,13 @@ Trade Details:
 - News Headlines: {headlines[:3]}  # Use top 3 headlines only
 """
 
-        response = client.chat.completions.create(
+        response = safe_chat_completion(
+            client,
             model=config.get_groq_model(),
             messages=[
                 {"role": "system", "content": "You are a professional crypto trading strategist."},
                 {"role": "user", "content": prompt}
-            ]
+            ],
         )
 
         return response.choices[0].message.content.strip()

--- a/news_filter.py
+++ b/news_filter.py
@@ -5,6 +5,7 @@ import os
 from dotenv import load_dotenv
 from log_utils import setup_logger
 import config
+from groq_safe import safe_chat_completion
 
 load_dotenv()
 logger = setup_logger(__name__)
@@ -51,9 +52,10 @@ Now here are the upcoming events:
 def analyze_news_with_llm(prompt):
     try:
         client = Groq(api_key=os.getenv("GROQ_API_KEY"))
-        response = client.chat.completions.create(
+        response = safe_chat_completion(
+            client,
             model=config.get_groq_model(),
-            messages=[{"role": "user", "content": prompt}]
+            messages=[{"role": "user", "content": prompt}],
         )
         reply = response.choices[0].message.content
         return json.loads(reply)

--- a/tests/test_dynamic_groq_model.py
+++ b/tests/test_dynamic_groq_model.py
@@ -1,23 +1,37 @@
 import importlib
-import types
+import json
 
 
-def test_llm_uses_mapped_model(monkeypatch):
-    monkeypatch.setenv("GROQ_MODEL", "llama-3.1-70b-versatile")
+def test_llm_retries_with_fallback_model(monkeypatch):
+    monkeypatch.setenv("GROQ_MODEL", "custom-model")
     monkeypatch.setenv("GROQ_API_KEY", "test-key")
     import groq_llm
     importlib.reload(groq_llm)
 
-    captured = {}
+    calls = []
 
-    def fake_post(url, headers, json):
-        captured["model"] = json["model"]
-        class Resp:
-            status_code = 200
-            def json(self):
-                return {"choices": [{"message": {"content": "ok"}}]}
-        return Resp()
+    class Resp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+            self.text = json.dumps(payload)
+
+        def json(self):
+            if isinstance(self._payload, dict):
+                return self._payload
+            raise ValueError("No JSON payload")
+
+    def fake_post(url, headers, json=None, **_):
+        calls.append(json["model"])
+        if len(calls) == 1:
+            return Resp(
+                400,
+                {"error": {"code": "model_decommissioned", "message": "custom-model retired"}},
+            )
+        return Resp(200, {"choices": [{"message": {"content": "ok"}}]})
 
     monkeypatch.setattr(groq_llm.requests, "post", fake_post)
-    groq_llm.get_llm_judgment("test prompt")
-    assert captured["model"] == "llama-3.1-70b"
+    result = groq_llm.get_llm_judgment("test prompt")
+
+    assert result == "ok"
+    assert calls == ["custom-model", groq_llm.config.DEFAULT_GROQ_MODEL]

--- a/tests/test_groq_model_mapping.py
+++ b/tests/test_groq_model_mapping.py
@@ -9,13 +9,16 @@ def reload_config():
 def test_default_model(monkeypatch):
     monkeypatch.delenv("GROQ_MODEL", raising=False)
     reload_config()
-    assert config.get_groq_model() == "llama-3.1-70b"
+    assert config.get_groq_model() == "llama-3.1-70b-versatile"
 
 
 def test_deprecated_model(monkeypatch):
-    monkeypatch.setenv("GROQ_MODEL", "llama-3.1-70b-versatile")
+    monkeypatch.setenv("GROQ_MODEL", "llama3-70b-8192")
     reload_config()
-    assert config.get_groq_model() == "llama-3.1-70b"
+    assert config.get_groq_model() == "llama-3.1-70b-versatile"
+    monkeypatch.setenv("GROQ_MODEL", "llama-3.1-70b")
+    reload_config()
+    assert config.get_groq_model() == "llama-3.1-70b-versatile"
     monkeypatch.delenv("GROQ_MODEL", raising=False)
     reload_config()
 

--- a/tests/test_trade_paths.py
+++ b/tests/test_trade_paths.py
@@ -19,6 +19,7 @@ def test_trade_paths(monkeypatch, tmp_path):
     assert agent.TRADE_HISTORY_FILE == trade_storage.TRADE_HISTORY_FILE
     assert dashboard.TRADE_HISTORY_FILE == trade_storage.TRADE_HISTORY_FILE
     completed_path = tmp_path / "completed.csv"
+    completed_path.write_text(",".join(trade_storage.TRADE_HISTORY_HEADERS))
     monkeypatch.setattr(trade_storage, "TRADE_HISTORY_FILE", str(completed_path))
     monkeypatch.setattr(trade_storage.os.path, "exists", lambda p: True)
     monkeypatch.setattr(trade_storage.os.path, "getsize", lambda p: 1)


### PR DESCRIPTION
## Summary
- map deprecated Groq model identifiers to the supported `llama-3.1-70b-versatile` default and normalise environment values
- add a shared `groq_safe` helper that retries Groq SDK and HTTP calls with the fallback model when a decommissioned model error is detected
- update Groq integrations and tests to use the resilient helper and cover the new behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d25eb1e0b4832d9c22bd9d87e1f240