### PR TITLE
Update Groq default model after decommission

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,14 +18,16 @@ def get(key: str, default: str | None = None) -> str | None:
 
 
 # Default Groq model and mapping for deprecated names.
-# ``llama3-70b-8192`` (and the shorter alias ``llama-3.1-70b``) have been
-# retired by Groq.  The currently supported drop-in replacement is
-# ``llama-3.1-70b-versatile`` which mirrors the earlier capabilities while
-# remaining available through the public API.
-DEFAULT_GROQ_MODEL = "llama-3.1-70b-versatile"
+# Groq periodically retires older Llama releases (for example the
+# ``llama-3.1-70b-versatile`` variant).  To keep the application working
+# without manual intervention we map known, deprecated identifiers to the
+# latest compatible default.  Update the mapping whenever Groq announces a
+# replacement model.
+DEFAULT_GROQ_MODEL = "llama-3.2-70b-versatile"
 _DEPRECATED_GROQ_MODELS = {
     "llama3-70b-8192": DEFAULT_GROQ_MODEL,
     "llama-3.1-70b": DEFAULT_GROQ_MODEL,
+    "llama-3.1-70b-versatile": DEFAULT_GROQ_MODEL,
 }
 _DEPRECATED_LOOKUP = {key.lower(): value for key, value in _DEPRECATED_GROQ_MODELS.items()}
 

--- a/tests/test_groq_model_mapping.py
+++ b/tests/test_groq_model_mapping.py
@@ -9,16 +9,19 @@ def reload_config():
 def test_default_model(monkeypatch):
     monkeypatch.delenv("GROQ_MODEL", raising=False)
     reload_config()
-    assert config.get_groq_model() == "llama-3.1-70b-versatile"
+    assert config.get_groq_model() == config.DEFAULT_GROQ_MODEL
 
 
 def test_deprecated_model(monkeypatch):
     monkeypatch.setenv("GROQ_MODEL", "llama3-70b-8192")
     reload_config()
-    assert config.get_groq_model() == "llama-3.1-70b-versatile"
+    assert config.get_groq_model() == config.DEFAULT_GROQ_MODEL
     monkeypatch.setenv("GROQ_MODEL", "llama-3.1-70b")
     reload_config()
-    assert config.get_groq_model() == "llama-3.1-70b-versatile"
+    assert config.get_groq_model() == config.DEFAULT_GROQ_MODEL
+    monkeypatch.setenv("GROQ_MODEL", "llama-3.1-70b-versatile")
+    reload_config()
+    assert config.get_groq_model() == config.DEFAULT_GROQ_MODEL
     monkeypatch.delenv("GROQ_MODEL", raising=False)
     reload_config()
 


### PR DESCRIPTION
## Summary
- update the Groq default model to `llama-3.2-70b-versatile` and map retired identifiers to the new default
- refresh the Groq model mapping tests to assert against the exported default constant and cover the retired alias

## Testing
- pytest tests/test_groq_model_mapping.py tests/test_dynamic_groq_model.py

------
https://chatgpt.com/codex/tasks/task_e_68d82265d42083219c6d9e3d60f4ebdb