### PR TITLE
Handle malformed trade CSV rows

### DIFF
--- a/tests/test_dashboard_csv_reader.py
+++ b/tests/test_dashboard_csv_reader.py
@@ -1,0 +1,41 @@
+import pandas as pd
+
+import dashboard
+
+
+def test_recover_unescaped_llm_error(tmp_path):
+    csv_text = (
+        "trade_id,timestamp,llm_error,volatility\n"
+        '1,2024-01-01T00:00:00Z,"{""error"": ""bad, stuff""}",0.25\n'
+    )
+    path = tmp_path / "history.csv"
+    path.write_text(csv_text, encoding="utf-8")
+
+    frame, recovered = dashboard._read_csv_with_recovery(path)
+
+    assert recovered == 0
+    assert frame.loc[0, "llm_error"] == '{"error": "bad, stuff"}'
+    assert frame.loc[0, "volatility"] == 0.25
+
+
+def test_recover_malformed_llm_error(tmp_path):
+    csv_text = (
+        "trade_id,timestamp,llm_error,volatility\n"
+        '1,2024-01-01T00:00:00Z,"{"error": "bad, stuff"}",0.25\n'
+    )
+    path = tmp_path / "history.csv"
+    path.write_text(csv_text, encoding="utf-8")
+
+    frame, recovered = dashboard._read_csv_with_recovery(path)
+
+    assert recovered == 1
+    assert frame.loc[0, "llm_error"].startswith(dashboard.PARSE_ERROR_TOKEN)
+    assert "bad, stuff" in frame.loc[0, "llm_error"]
+    assert frame.loc[0, "volatility"] == "0.25"
+
+
+def test_normalise_time_exit_column():
+    df = pd.DataFrame({"time_exit": ["2024-06-01T00:00:00Z"]})
+    normalised = dashboard.normalise_history_columns(df)
+    assert "exit_time" in normalised.columns
+    assert normalised.loc[0, "exit_time"] == "2024-06-01T00:00:00Z"

--- a/trade_schema.py
+++ b/trade_schema.py
@@ -87,6 +87,7 @@ COLUMN_SYNONYMS: Dict[str, str] = {
     "exitprice": "exit",
     "exit": "exit",
     "exittime": "exit_time",
+    "timeexit": "exit_time",
     "exittimestamp": "exit_time",
     "positionsize": "position_size",
     "qty": "position_size",


### PR DESCRIPTION
## Summary
- add resilient CSV loader for the dashboard that repairs malformed rows and surfaces parse errors per column
- normalise historical headers so `time_exit` aliases to `exit_time`
- add regression tests covering CSV recovery behaviour and header normalisation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d82fcbaa908321945e5e77c726d41a