### PR TITLE
Fix dashboard TP status highlighting

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -584,11 +584,24 @@ def get_price_history(
 
 
 def to_bool(val) -> bool:
-    """Convert common string/int representations to a boolean."""
+    """Convert ``val`` into a boolean, handling loose string inputs."""
+
     if isinstance(val, bool):
         return val
     if isinstance(val, str):
-        return val.lower() in {"true", "1", "yes"}
+        token = val.strip().lower()
+        return token in {
+            "true",
+            "1",
+            "yes",
+            "y",
+            "on",
+            "enabled",
+            "active",
+            "hit",
+            "triggered",
+            "reached",
+        }
     return bool(val)
 
 def format_active_row(symbol: str, data: dict) -> dict | None:

--- a/tests/test_dashboard_to_bool.py
+++ b/tests/test_dashboard_to_bool.py
@@ -1,0 +1,19 @@
+import pytest
+
+from dashboard import to_bool
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, "true", "True", " true ", "1", "Yes", "y", "on", "enabled", "active", "hit", "triggered", "reached"],
+)
+def test_to_bool_truthy(value):
+    assert to_bool(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [False, "false", "0", "no", "", None, 0],
+)
+def test_to_bool_falsy(value):
+    assert to_bool(value) is False


### PR DESCRIPTION
## Summary
- make the dashboard's `to_bool` helper resilient to loosely formatted strings such as "hit" or " true " so TP statuses display correctly
- add regression tests that cover the extended set of truthy and falsy tokens

## Testing
- pytest tests/test_dashboard_to_bool.py

------
https://chatgpt.com/codex/tasks/task_e_68d9dbf318d4832188e11538be812c93