### PR TITLE
Improve trade status boolean parsing

### DIFF
--- a/tests/test_dashboard_to_bool.py
+++ b/tests/test_dashboard_to_bool.py
@@ -5,7 +5,28 @@ from dashboard import to_bool
 
 @pytest.mark.parametrize(
     "value",
-    [True, "true", "True", " true ", "1", "Yes", "y", "on", "enabled", "active", "hit", "triggered", "reached"],
+    [
+        True,
+        "true",
+        "True",
+        " true ",
+        "1",
+        "Yes",
+        "y",
+        "on",
+        "enabled",
+        "active",
+        "hit",
+        " Hit ",
+        "triggered",
+        " triggered ",
+        "reached",
+        "target hit",
+        "TARGET REACHED",
+        "tp1_hit",
+        "EXECUTED",
+        "done",
+    ],
 )
 def test_to_bool_truthy(value):
     assert to_bool(value) is True
@@ -13,7 +34,7 @@ def test_to_bool_truthy(value):
 
 @pytest.mark.parametrize(
     "value",
-    [False, "false", "0", "no", "", None, 0],
+    [False, "false", "0", "no", "", None, 0, "pending", " waiting "],
 )
 def test_to_bool_falsy(value):
     assert to_bool(value) is False


### PR DESCRIPTION
## Summary
- expand the dashboard `to_bool` helper to normalise composite strings and recognise additional truthy status tokens
- add regression coverage for whitespace-padded, mixed-case, and composite trade status values along with extra falsy cases

## Testing
- pytest tests/test_dashboard_to_bool.py tests/test_trade_history_columns.py tests/test_trade_history_narrative.py tests/test_trade_history_pnl_pct.py tests/test_trade_history_notional_fallback.py tests/test_trade_history_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d9e09ae80483219ac50fbff50b8ba4