### PR TITLE
Handle negated composite status keywords

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -624,7 +624,72 @@ def to_bool(val) -> bool:
             "done",
             "achieved",
         }
-        return bool(words & keyword_hits)
+        if not words & keyword_hits:
+            return False
+        negation_terms = {
+            "not",
+            "no",
+            "never",
+            "none",
+            "without",
+            "pending",
+            "await",
+            "awaited",
+            "awaiting",
+            "wait",
+            "waited",
+            "waiting",
+            "miss",
+            "missed",
+            "missing",
+            "fail",
+            "failed",
+            "failing",
+            "cancel",
+            "canceled",
+            "cancelled",
+            "void",
+            "voided",
+            "skip",
+            "skipped",
+            "hold",
+            "holding",
+            "inactive",
+            "halt",
+            "halted",
+            "blocked",
+            "stopped",
+            "pause",
+            "paused",
+            "unfilled",
+            "untriggered",
+            "unhit",
+            "unreached",
+            "unmet",
+            "undo",
+            "undone",
+            "notfilled",
+            "nottriggered",
+            "nothit",
+            "notreached",
+            "partial",
+            "partially",
+            "partialfill",
+            "partialfilled",
+            "tbd",
+        }
+        if words & negation_terms:
+            return False
+        negation_pattern = re.compile(
+            r"(^|[^a-z])(" +
+            "|".join(
+                sorted((re.escape(term) for term in negation_terms), key=len, reverse=True)
+            ) +
+            r")([^a-z]|$)"
+        )
+        if negation_pattern.search(token):
+            return False
+        return True
     return bool(val)
 
 def format_active_row(symbol: str, data: dict) -> dict | None:

--- a/tests/test_to_bool.py
+++ b/tests/test_to_bool.py
@@ -1,0 +1,13 @@
+from dashboard import to_bool
+
+
+def test_to_bool_detects_negated_words():
+    assert to_bool("Not triggered") is False
+    assert to_bool("tp1_not_hit") is False
+    assert to_bool("SL not reached") is False
+    assert to_bool("pending hit") is False
+
+
+def test_to_bool_positive_keywords_without_negation():
+    assert to_bool("tp hit") is True
+    assert to_bool("target reached") is True


### PR DESCRIPTION
## Summary
- detect negating tokens before treating composite status strings as truthy in `to_bool`
- add regression tests for negated trade status phrases and positive hits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db2113827c8321b107f44b57bc11ef