### PR TITLE
Switch Groq default model to llama-3.3-70b-versatile

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,8 +22,9 @@ def get(key: str, default: str | None = None) -> str | None:
 # ``llama-3.1-70b-versatile`` variant).  To keep the application working
 # without manual intervention we map known, deprecated identifiers to the
 # latest compatible default.  Update the mapping whenever Groq announces a
-# replacement model.
-DEFAULT_GROQ_MODEL = "llama-3.2-70b-versatile"
+# replacement model.  The current production-ready choice is ``llama-3.3-70b-
+# versatile`` which Groq lists as the successor for the retired 3.1 models.
+DEFAULT_GROQ_MODEL = "llama-3.3-70b-versatile"
 _DEPRECATED_GROQ_MODELS = {
     "llama3-70b-8192": DEFAULT_GROQ_MODEL,
     "llama-3.1-70b": DEFAULT_GROQ_MODEL,


### PR DESCRIPTION
## Summary
- set the Groq default model to the active `llama-3.3-70b-versatile` release used across the application
- keep deprecated identifiers mapped to the new default so existing callers stay aligned

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db2e157b5c8321a8ccc21193e0465d