### PR TITLE
Map deprecated Groq llama-3.2 IDs to current default

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,12 +23,15 @@ def get(key: str, default: str | None = None) -> str | None:
 # without manual intervention we map known, deprecated identifiers to the
 # latest compatible default.  Update the mapping whenever Groq announces a
 # replacement model.  The current production-ready choice is ``llama-3.3-70b-
-# versatile`` which Groq lists as the successor for the retired 3.1 models.
+# versatile`` which Groq lists as the successor for the retired 3.1 and 3.2
+# models.
 DEFAULT_GROQ_MODEL = "llama-3.3-70b-versatile"
 _DEPRECATED_GROQ_MODELS = {
     "llama3-70b-8192": DEFAULT_GROQ_MODEL,
     "llama-3.1-70b": DEFAULT_GROQ_MODEL,
     "llama-3.1-70b-versatile": DEFAULT_GROQ_MODEL,
+    "llama-3.2-70b": DEFAULT_GROQ_MODEL,
+    "llama-3.2-70b-versatile": DEFAULT_GROQ_MODEL,
 }
 _DEPRECATED_LOOKUP = {key.lower(): value for key, value in _DEPRECATED_GROQ_MODELS.items()}
 


### PR DESCRIPTION
## Summary
- map the previously default llama-3.2 Groq model identifiers to the llama-3.3-70b-versatile default
- document that the current default replaces both 3.1 and 3.2 series identifiers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db337836708321b3cc9054de15cb46