### PR TITLE
Ensure performance metrics always expose default keys

### DIFF
--- a/trade_utils.py
+++ b/trade_utils.py
@@ -719,12 +719,21 @@ def _extract_trade_returns(df: pd.DataFrame) -> pd.Series:
     return returns
 
 
+_DEFAULT_PERFORMANCE_METRICS = {
+    "sharpe": float("nan"),
+    "calmar": float("nan"),
+    "max_drawdown": float("nan"),
+    "var": float("nan"),
+    "es": float("nan"),
+}
+
+
 def compute_performance_metrics(log_file: str = TRADE_HISTORY_FILE, lookback: int = 100) -> dict:
     """Return risk-adjusted performance metrics from the trade log."""
 
     use_default_source = log_file == TRADE_HISTORY_FILE
     if not use_default_source and (not log_file or not os.path.exists(log_file)):
-        return {}
+        return dict(_DEFAULT_PERFORMANCE_METRICS)
 
     try:
         if use_default_source:
@@ -733,7 +742,7 @@ def compute_performance_metrics(log_file: str = TRADE_HISTORY_FILE, lookback: in
             df = load_trade_history_df(log_file)
 
         if df.empty:
-            return {}
+            return dict(_DEFAULT_PERFORMANCE_METRICS)
 
         sort_cols = [col for col in ("exit_time", "timestamp") if col in df.columns]
         if sort_cols:
@@ -743,7 +752,7 @@ def compute_performance_metrics(log_file: str = TRADE_HISTORY_FILE, lookback: in
 
         returns = _extract_trade_returns(df)
         if returns.empty:
-            return {}
+            return dict(_DEFAULT_PERFORMANCE_METRICS)
 
         equity_curve = (1 + returns).cumprod()
         metrics = {
@@ -758,7 +767,7 @@ def compute_performance_metrics(log_file: str = TRADE_HISTORY_FILE, lookback: in
         logger.exception(
             "Failed to compute performance metrics from %s: %s", log_file, exc
         )
-        return {}
+        return dict(_DEFAULT_PERFORMANCE_METRICS)
 
 
 def get_last_trade_outcome(log_file: str = TRADE_HISTORY_FILE) -> str | None:


### PR DESCRIPTION
## Summary
- add a shared default metric payload so compute_performance_metrics always returns the expected keys
- fall back to the default payload whenever the trade log is missing, empty, or fails to parse

## Testing
- pytest Spot-Ai-Agent/tests/test_performance_metrics.py *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68dd0ec1d69c832194ff999d1e2fce36