### PR TITLE
Enforce entry timestamp requirement in trade logs

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -19,6 +19,8 @@ working directory.
 from datetime import datetime, timedelta, timezone
 from typing import List, Tuple, Optional, Union
 
+import pandas as pd
+
 from trade_utils import (
     get_price_data,
     calculate_indicators,
@@ -428,10 +430,10 @@ def manage_trades() -> None:
 
         if entry_dt is None:
             logger.warning(
-                "%s missing valid entry_time; forcing max holding time exit on next cycle.",
+                "%s missing valid entry_time; assigning current time for hold duration tracking.",
                 symbol,
             )
-            entry_dt = datetime.utcnow() - MAX_HOLDING_TIME
+            entry_dt = datetime.utcnow()
             trade['entry_time'] = entry_dt.strftime("%Y-%m-%d %H:%M:%S")
         elif entry_source_used != 'entry_time':
             logger.warning(
@@ -503,7 +505,10 @@ def manage_trades() -> None:
         recent_high: float
         recent_low: float
         if entry_dt is not None:
-            recent_candles = price_data[price_data.index >= entry_dt]
+            if isinstance(price_data.index, pd.DatetimeIndex):
+                recent_candles = price_data[price_data.index >= entry_dt]
+            else:
+                recent_candles = price_data
             if not recent_candles.empty:
                 recent_high = recent_candles['high'].iloc[-1]
                 recent_low = recent_candles['low'].iloc[-1]

--- a/trade_storage.py
+++ b/trade_storage.py
@@ -94,7 +94,9 @@ def _parse_header_columns(header_line: str) -> list[str]:
     return [segment.strip().strip('"') for segment in cleaned.split(",")]
 
 
-def _header_is_compatible(header_line: str, headers: Sequence[str]) -> bool:
+def _header_is_compatible(
+    header_line: str, headers: Sequence[str], *, require_essential: bool = False
+) -> bool:
     """Return ``True`` when ``header_line`` resembles a supported schema."""
 
     tokens = _normalise_header_line(header_line)
@@ -110,6 +112,9 @@ def _header_is_compatible(header_line: str, headers: Sequence[str]) -> bool:
         return False
 
     essential = set(_EXPECTED_HISTORY_KEYS)
+    if require_essential:
+        return essential.issubset(recognised)
+
     if recognised & essential:
         return True
 
@@ -755,7 +760,7 @@ def log_trade_result(
                 "Unable to inspect trade history header %s: %s", TRADE_HISTORY_FILE, exc
             )
             first_line = ""
-        if _header_is_compatible(first_line, headers):
+        if _header_is_compatible(first_line, headers, require_essential=True):
             header_needed = False
             existing_headers = _parse_header_columns(first_line)
             if existing_headers:


### PR DESCRIPTION
## Summary
- require essential entry and exit columns when validating historical trade headers so legacy logs missing them are rebuilt with the updated schema
- backfill missing trade entry timestamps with the current time during management and guard against non-datetime price indexes when slicing recent candles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd4b7149e48321892dd5fa22185da2