### PR TITLE
Separate strategy and pattern logging

### DIFF
--- a/tests/test_stop_loss_update.py
+++ b/tests/test_stop_loss_update.py
@@ -1,5 +1,7 @@
 import trade_manager
 import trade_utils
+from datetime import datetime, timedelta
+
 import pandas as pd
 import pytest
 
@@ -65,6 +67,7 @@ def test_profit_riding_trails_stop_loss(monkeypatch):
         'profit_riding': True,
         'trail_tp_pct': 0.05,
         'next_trail_tp': 150.0,
+        'entry_time': datetime.utcnow().isoformat() + 'Z',
     }
 
     def fake_load():
@@ -76,7 +79,11 @@ def test_profit_riding_trails_stop_loss(monkeypatch):
         saved['trades'] = trades
 
     def fake_price_data(symbol):
-        return pd.DataFrame({'close': [151.0], 'high': [151.0], 'low': [151.0]})
+        now = datetime.utcnow()
+        idx = pd.DatetimeIndex([now - timedelta(minutes=1)])
+        return pd.DataFrame(
+            {'close': [151.0], 'high': [151.0], 'low': [151.0]}, index=idx
+        )
 
     def fake_commission(symbol, quantity, maker):
         return 0.0

--- a/tests/test_trade_storage.py
+++ b/tests/test_trade_storage.py
@@ -31,6 +31,7 @@ def test_log_trade_result_extended_fields(tmp_path, monkeypatch):
         "htf_trend": 10.0,
         "order_imbalance": 5.0,
         "macro_indicator": 20.0,
+        "pattern": "double_bottom",
     }
     trade_storage.log_trade_result(trade, outcome="tp1", exit_price=1100)
     with open(csv_path, newline="") as f:
@@ -51,6 +52,7 @@ def test_log_trade_result_extended_fields(tmp_path, monkeypatch):
     assert float(rows[0]["notional_tp2"]) == 0.0
     assert rows[0]["tp1_partial"] == "False"
     assert rows[0]["tp2_partial"] == "False"
+    assert rows[0]["pattern"] == "double_bottom"
 
 
 def test_log_trade_result_reassigns_misplaced_strategy_and_session(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- derive a descriptive strategy label when opening trades so the log distinguishes high-level strategies from specific patterns
- repair trade history header handling to guarantee the pattern column is retained, rebuilding legacy files if necessary
- extend tests to assert the pattern field is logged and align stop-loss fixtures with realistic trade metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dd4da4ac2c8321b73a4d22ac66e2c5