### PR TITLE
Upgrade ML models with diagnostics and adaptive policy controls

### DIFF
--- a/sequence_model.py
+++ b/sequence_model.py
@@ -1,30 +1,44 @@
-"""
-Sequence‑based model utilities for the Spot‑AI Agent.
+"""Advanced sequence modelling utilities for the Spot‑AI Agent.
 
-This module implements a simple tree‑based sequence model using
-scikit‑learn's ``RandomForestRegressor`` to predict the next‑bar return
-from a rolling window of recent features. It provides lightweight
-functionality compatible with environments lacking deep‑learning
-libraries.
+The module now supports multiple regressors, automated model selection,
+validation metrics, and interpretability diagnostics so that the
+time-series pipeline can be audited and tuned like the primary
+classifier.
 """
 
 import os
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
 from log_utils import setup_logger
 
 try:
-    from sklearn.ensemble import RandomForestRegressor
+    from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
+    from sklearn.ensemble import HistGradientBoostingRegressor
+except Exception:  # pragma: no cover - optional dependency
+    HistGradientBoostingRegressor = None  # type: ignore
+
+try:
     from sklearn.preprocessing import StandardScaler
-    from sklearn.model_selection import cross_val_score
+    from sklearn.model_selection import TimeSeriesSplit
+    from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
+    from sklearn.base import clone
+    from sklearn.inspection import permutation_importance
     import joblib  # type: ignore
     SKLEARN_AVAILABLE = True
 except Exception:  # pragma: no cover - optional dependency
     RandomForestRegressor = None  # type: ignore
+    GradientBoostingRegressor = None  # type: ignore
+    HistGradientBoostingRegressor = None  # type: ignore
     StandardScaler = None  # type: ignore
-    cross_val_score = None  # type: ignore
+    TimeSeriesSplit = None  # type: ignore
+    mean_squared_error = None  # type: ignore
+    mean_absolute_error = None  # type: ignore
+    r2_score = None  # type: ignore
+    clone = None  # type: ignore
+    permutation_importance = None  # type: ignore
     joblib = None  # type: ignore
     SKLEARN_AVAILABLE = False
 
@@ -45,6 +59,92 @@ ROOT_DIR = os.path.dirname(__file__)
 SEQ_PKL = os.path.join(ROOT_DIR, "sequence_model.pkl")
 
 
+@dataclass
+class SequenceTrainingDiagnostics:
+    """Diagnostics returned when training the sequence model."""
+
+    model_type: str
+    metrics: Dict[str, float]
+    feature_importance: Dict[str, float]
+    window_size: int
+    samples: int
+
+
+def _compute_regression_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> Dict[str, float]:
+    metrics: Dict[str, float] = {}
+    if mean_squared_error is not None:
+        try:
+            mse = float(mean_squared_error(y_true, y_pred))
+            metrics['mse'] = mse
+            metrics['rmse'] = float(np.sqrt(mse))
+        except Exception:
+            metrics['mse'] = float('nan')
+            metrics['rmse'] = float('nan')
+    if mean_absolute_error is not None:
+        try:
+            metrics['mae'] = float(mean_absolute_error(y_true, y_pred))
+        except Exception:
+            metrics['mae'] = float('nan')
+    if r2_score is not None:
+        try:
+            metrics['r2'] = float(r2_score(y_true, y_pred))
+        except Exception:
+            metrics['r2'] = float('nan')
+    try:
+        metrics['mape'] = float(np.mean(np.abs((y_true - y_pred) / (y_true + 1e-8))))
+    except Exception:
+        metrics['mape'] = float('nan')
+    return metrics
+
+
+def _evaluate_candidate(
+    model: Any,
+    X: np.ndarray,
+    y: np.ndarray,
+    splitter: "TimeSeriesSplit",
+) -> float:
+    scores: List[float] = []
+    for train_idx, test_idx in splitter.split(X):
+        X_train, X_test = X[train_idx], X[test_idx]
+        y_train, y_test = y[train_idx], y[test_idx]
+        try:
+            estimator = clone(model) if clone is not None else model.__class__(**model.get_params())
+        except Exception:
+            estimator = model
+        estimator.fit(X_train, y_train)
+        preds = np.asarray(estimator.predict(X_test), dtype=float)
+        rmse = float(np.sqrt(np.mean((preds - y_test) ** 2)))
+        scores.append(-rmse)
+    return float(np.mean(scores)) if scores else float('-inf')
+
+
+def _compute_feature_importance(
+    model: Any,
+    X: np.ndarray,
+    y: np.ndarray,
+    base_features: List[str],
+    window_size: int,
+) -> Dict[str, float]:
+    if permutation_importance is None:
+        return {}
+    try:
+        perm = permutation_importance(model, X, y, n_repeats=10, random_state=42)
+    except Exception:
+        return {}
+    try:
+        importances = perm.importances_mean.reshape(window_size, len(base_features))
+    except Exception:
+        importances = np.zeros((window_size, len(base_features)))
+    aggregated = np.abs(importances).mean(axis=0)
+    total = float(np.sum(aggregated))
+    if total <= 0:
+        return {}
+    importance_map = {
+        feature: float(value / total) for feature, value in zip(base_features, aggregated)
+    }
+    return dict(sorted(importance_map.items(), key=lambda kv: kv[1], reverse=True))
+
+
 def _build_sequences(df: pd.DataFrame, window_size: int) -> (np.ndarray, np.ndarray):
     """Convert a DataFrame into overlapping sequences and target returns."""
     returns = df['close'].pct_change().fillna(0.0).to_numpy()
@@ -59,67 +159,127 @@ def _build_sequences(df: pd.DataFrame, window_size: int) -> (np.ndarray, np.ndar
     return np.array(X), np.array(y)
 
 
-def train_sequence_model(df: pd.DataFrame, window_size: int = 10) -> None:
-    """Train a simple sequence‑to‑one regression model on historical data."""
+def train_sequence_model(df: pd.DataFrame, window_size: int = 10) -> Optional[SequenceTrainingDiagnostics]:
+    """Train an ensemble of sequence models and persist the best performer."""
     if not SKLEARN_AVAILABLE:
         logger.warning("scikit-learn not available; cannot train sequence model.")
-        return
+        return None
     if df is None or len(df) < window_size + 2:
         logger.warning("Not enough data to train sequence model.")
-        return
+        return None
     X, y = _build_sequences(df.reset_index(drop=True), window_size)
     if X.size == 0:
         logger.warning("Failed to construct sequences from data.")
-        return
+        return None
+    split_idx = max(window_size, int(len(X) * 0.8))
+    split_idx = min(split_idx, len(X) - 1)
+    if split_idx <= 0:
+        logger.warning("Insufficient samples after sequence construction.")
+        return None
+    X_train, X_val = X[:split_idx], X[split_idx:]
+    y_train, y_val = y[:split_idx], y[split_idx:]
+    if len(X_val) == 0:
+        X_val = X_train[-window_size:]
+        y_val = y_train[-window_size:]
     scaler = StandardScaler()
-    X_norm = scaler.fit_transform(X)
+    X_train_norm = scaler.fit_transform(X_train)
+    X_val_norm = scaler.transform(X_val)
 
-    models = {
-        'random_forest': RandomForestRegressor(n_estimators=100, max_depth=5, random_state=42),
+    models: Dict[str, Any] = {
+        'random_forest': RandomForestRegressor(n_estimators=200, max_depth=7, random_state=42),
     }
+    if GradientBoostingRegressor is not None:
+        models['gradient_boosting'] = GradientBoostingRegressor(random_state=42)
+    if HistGradientBoostingRegressor is not None:
+        models['hist_gradient'] = HistGradientBoostingRegressor(random_state=42)
     if XGBRegressor is not None:
         models['xgboost'] = XGBRegressor(
-            n_estimators=200,
+            n_estimators=300,
             max_depth=4,
-            learning_rate=0.1,
+            learning_rate=0.05,
             subsample=0.8,
             objective='reg:squarederror',
         )
     if LGBMRegressor is not None:
         models['lightgbm'] = LGBMRegressor(
-            n_estimators=200,
-            num_leaves=31,
-            learning_rate=0.1,
+            n_estimators=300,
+            num_leaves=63,
+            learning_rate=0.05,
             max_depth=-1,
         )
 
-    best_model_name = 'random_forest'
-    best_score = float('-inf')
-    for name, model in models.items():
-        try:
-            scores = cross_val_score(model, X_norm, y, cv=3, scoring='neg_mean_squared_error')
-            score = float(scores.mean())
-        except Exception:
-            score = float('-inf')
-        logger.info("%s CV neg-MSE: %.6f", name, score)
-        if score > best_score:
-            best_score = score
-            best_model_name = name
+    splitter = None
+    if TimeSeriesSplit is not None and len(X_train_norm) > 3:
+        n_splits = min(5, max(2, len(X_train_norm) // max(1, window_size // 2 or 1)))
+        if n_splits >= len(X_train_norm):
+            n_splits = len(X_train_norm) - 1
+        if n_splits >= 2:
+            splitter = TimeSeriesSplit(n_splits=n_splits)
 
-    best_model = models[best_model_name]
-    best_model.fit(X_norm, y)
+    best_model_name = ''
+    best_estimator: Optional[Any] = None
+    best_score = float('-inf')
+    val_predictions: Optional[np.ndarray] = None
+    for name, template in models.items():
+        try:
+            estimator = clone(template) if clone is not None else template.__class__(**template.get_params())
+        except Exception:
+            estimator = template
+        estimator.fit(X_train_norm, y_train)
+        val_pred = np.asarray(estimator.predict(X_val_norm), dtype=float)
+        val_rmse = -float(np.sqrt(np.mean((val_pred - y_val) ** 2))) if len(y_val) else float('-inf')
+        cv_score = val_rmse
+        if splitter is not None:
+            try:
+                cv_score = _evaluate_candidate(template, X_train_norm, y_train, splitter)
+            except Exception as exc:
+                logger.warning("Time-series CV failed for %s: %s", name, exc, exc_info=True)
+        combined_score = 0.5 * cv_score + 0.5 * val_rmse
+        logger.info("Sequence model %s -> CV score %.6f | validation score %.6f", name, cv_score, val_rmse)
+        if combined_score > best_score:
+            best_score = combined_score
+            best_model_name = name
+            best_estimator = estimator
+            val_predictions = val_pred
+
+    if best_estimator is None:
+        logger.warning("Failed to select a sequence model candidate.")
+        return None
+
+    metrics = _compute_regression_metrics(y_val, val_predictions if val_predictions is not None else y_val)
+    scaler_full = StandardScaler()
+    X_full_norm = scaler_full.fit_transform(X)
     try:
-        joblib.dump({
-            'model': best_model,
-            'scaler_mean': scaler.mean_,
-            'scaler_scale': scaler.scale_,
-            'window_size': window_size,
-            'feature_dim': X.shape[1],
-            'model_type': best_model_name,
-        }, SEQ_PKL)
-        logger.info("Sequence model (%s) trained and saved to %s", best_model_name, SEQ_PKL)
+        final_model = clone(best_estimator) if clone is not None else best_estimator.__class__(**best_estimator.get_params())
+    except Exception:
+        final_model = best_estimator
+    final_model.fit(X_full_norm, y)
+    base_features = [col for col in df.columns if col not in {'timestamp', 'close'}]
+    feature_importance = _compute_feature_importance(final_model, X_full_norm, y, base_features, window_size)
+
+    artefact = {
+        'model': final_model,
+        'scaler_mean': scaler_full.mean_,
+        'scaler_scale': scaler_full.scale_,
+        'window_size': window_size,
+        'feature_dim': X.shape[1],
+        'model_type': best_model_name,
+        'metrics': metrics,
+        'feature_names': base_features,
+        'feature_importance': feature_importance,
+    }
+    try:
+        joblib.dump(artefact, SEQ_PKL)
+        logger.info("Sequence model (%s) trained with RMSE %.6f and saved to %s", best_model_name, metrics.get('rmse', float('nan')), SEQ_PKL)
     except Exception as e:  # pragma: no cover - IO errors
         logger.warning("Failed to save sequence model: %s", e, exc_info=True)
+    return SequenceTrainingDiagnostics(
+        model_type=best_model_name,
+        metrics=metrics,
+        feature_importance=feature_importance,
+        window_size=window_size,
+        samples=len(X),
+    )
 
 
 def _load_sequence_model() -> Optional[dict]:
@@ -129,6 +289,21 @@ def _load_sequence_model() -> Optional[dict]:
         return joblib.load(SEQ_PKL)
     except Exception:  # pragma: no cover
         return None
+
+
+def load_sequence_model_report() -> Dict[str, Any]:
+    """Return persisted metadata for the trained sequence model."""
+
+    artefact = _load_sequence_model()
+    if not artefact:
+        return {}
+    report = {
+        'model_type': artefact.get('model_type'),
+        'metrics': artefact.get('metrics', {}),
+        'window_size': artefact.get('window_size'),
+        'feature_importance': artefact.get('feature_importance', {}),
+    }
+    return report
 
 
 def predict_next_return(window_df: pd.DataFrame) -> float:

--- a/tests/test_ml_pipeline.py
+++ b/tests/test_ml_pipeline.py
@@ -1,0 +1,122 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import ml_model
+import sequence_model
+import rl_policy
+import trade_storage
+
+
+def _build_trade_history(rows: int = 80) -> pd.DataFrame:
+    base_time = pd.Timestamp('2024-01-01')
+    records = []
+    sessions = ['Asia', 'Europe', 'US']
+    for i in range(rows):
+        entry = base_time + pd.Timedelta(hours=i)
+        exit_time = entry + pd.Timedelta(hours=4)
+        outcome = 'tp1' if i % 2 else 'loss'
+        records.append({
+            'entry_time': entry.isoformat(),
+            'exit_time': exit_time.isoformat(),
+            'score': 55 + (i % 10),
+            'confidence': 5 + (i % 4),
+            'session': sessions[i % len(sessions)],
+            'btc_dominance': 45 + (i % 5),
+            'fear_greed': 40 + (i % 10),
+            'sentiment_confidence': 6 + (i % 3),
+            'sentiment_bias': 'bullish' if i % 3 else 'bearish',
+            'pattern': f'pattern_{i % 5}',
+            'volatility': 18 + (i % 6),
+            'htf_trend': 4 + (i % 3),
+            'order_imbalance': (-1) ** i * 5,
+            'macro_indicator': 2 + (i % 2),
+            'macd': 1.2 + (i % 3) * 0.1,
+            'rsi': 55 + (i % 5),
+            'sma': 1.1 + (i % 4) * 0.05,
+            'atr': 0.8 + (i % 4) * 0.02,
+            'volume': 1_000_000 + i * 1500,
+            'llm_approval': bool(i % 3),
+            'llm_confidence': 7 + (i % 2),
+            'outcome': outcome,
+            'btc_dominance_change': 0.2,
+            'htf_bias': 'bull',
+            'fear_greed_rolling': 50 + (i % 4),
+            'sentiment_score': 0.1 * ((-1) ** i),
+        })
+    return pd.DataFrame(records)
+
+
+def test_train_model_generates_metrics(tmp_path, monkeypatch):
+    history_df = _build_trade_history()
+    history_path = tmp_path / 'history.csv'
+    history_df.to_csv(history_path, index=False)
+
+    monkeypatch.setattr(ml_model, 'LOG_FILE', str(history_path))
+    monkeypatch.setattr(ml_model, 'MODEL_JSON', str(tmp_path / 'ml_model.json'))
+    monkeypatch.setattr(ml_model, 'MODEL_PKL', str(tmp_path / 'ml_model.pkl'))
+    monkeypatch.setattr(trade_storage, 'TRADE_HISTORY_FILE', str(history_path))
+
+    diagnostics = ml_model.train_model()
+    assert diagnostics is not None
+    if ml_model.SKLEARN_AVAILABLE:
+        assert diagnostics.validation_metrics
+    else:
+        assert diagnostics.model_type == 'manual'
+    report = ml_model.load_model_report()
+    if ml_model.SKLEARN_AVAILABLE:
+        assert report.get('validation_metrics')
+    else:
+        assert report.get('model_type') == 'manual'
+    prob = ml_model.predict_success_probability(
+        score=60,
+        confidence=7,
+        session='US',
+        btc_d=52,
+        fg=55,
+        sentiment_conf=7,
+        pattern='pattern_1',
+        llm_approval=True,
+        llm_confidence=8,
+        feature_overrides={'volatility': 0.25},
+    )
+    assert 0.0 <= prob <= 1.0
+
+
+def test_sequence_model_training(tmp_path, monkeypatch):
+    rows = 160
+    ts = pd.date_range('2024-01-01', periods=rows, freq='H')
+    df = pd.DataFrame({
+        'timestamp': ts,
+        'close': np.linspace(100, 120, rows) + np.sin(np.linspace(0, 6, rows)),
+        'feature_a': np.cos(np.linspace(0, 3, rows)),
+        'feature_b': np.linspace(0.1, 0.9, rows),
+    })
+    monkeypatch.setattr(sequence_model, 'SEQ_PKL', str(tmp_path / 'sequence.pkl'))
+
+    diagnostics = sequence_model.train_sequence_model(df, window_size=8)
+    if not sequence_model.SKLEARN_AVAILABLE:
+        pytest.skip("scikit-learn not available for sequence model test")
+    assert diagnostics is not None
+    assert diagnostics.metrics
+    artefact = sequence_model._load_sequence_model()
+    assert artefact is not None
+    assert artefact['metrics']
+    report = sequence_model.load_sequence_model_report()
+    assert report.get('model_type')
+    window = df.tail(8)
+    pred = sequence_model.predict_next_return(window)
+    assert isinstance(pred, float)
+
+
+def test_rl_policy_adaptive_behaviour(tmp_path, monkeypatch):
+    monkeypatch.setattr(rl_policy, 'POLICY_FILE', str(tmp_path / 'rl_policy.json'))
+    sizer = rl_policy.RLPositionSizer(epsilon=0.5, epsilon_decay=0.8, min_epsilon=0.1)
+    initial_epsilon = sizer.epsilon
+    state = 'winning_state'
+    action = sizer.select_multiplier(state)
+    sizer.update(state, action, reward=3.0)
+    assert sizer.state_action_visits[(state, action)] == 1
+    assert sizer.epsilon <= initial_epsilon
+    summary = sizer.policy_summary()
+    assert state in summary


### PR DESCRIPTION
## Summary
- enrich the classification trainer with calibration, validation metrics, feature attribution, and metadata helpers
- overhaul the sequence forecaster to perform model selection, compute diagnostics, and surface interpretability reports
- extend the reinforcement-learning position sizer with adaptive exploration, reward clipping, and human-readable summaries
- add regression tests covering the upgraded ML pipeline and RL behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dd4e659d34832180ab7d5583c17cf3