### PR TITLE
Increase maximum holding time exit to six hours

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -56,7 +56,7 @@ ATR_MULTIPLIER = 1.0
 # Require fairly high confidence before exiting on bearish macro signals
 MACRO_CONFIDENCE_EXIT_THRESHOLD = 7
 # Maximum duration to hold a trade before forcing exit
-MAX_HOLDING_TIME = timedelta(hours=1)
+MAX_HOLDING_TIME = timedelta(hours=6)
 
 logger = setup_logger(__name__)
 rl_sizer = RLPositionSizer()


### PR DESCRIPTION
## Summary
- extend the maximum holding time threshold for trades from one hour to six hours

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dd7a1aa1508321a5778313b4507cd1