### PR TITLE
Fix closed status handling for boolean flags

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -573,7 +573,7 @@ def _status_token_is_closed(value) -> bool:
     if value is None:
         return False
     if isinstance(value, bool):
-        return not value
+        return bool(value)
     if isinstance(value, (int, float)):
         # Numerical status codes of zero commonly indicate inactivity
         return float(value) == 0.0

--- a/tests/test_dashboard_live_positions.py
+++ b/tests/test_dashboard_live_positions.py
@@ -40,6 +40,7 @@ def test_is_trade_closed_heuristics(monkeypatch):
     assert dashboard._is_trade_closed({"status": "closed"}) is True
     assert dashboard._is_trade_closed({"is_open": False}) is True
     assert dashboard._is_trade_closed({"status": {"closed": "true"}}) is True
+    assert dashboard._is_trade_closed({"status": {"closed": False}}) is False
     assert dashboard._is_trade_closed({"status": "open"}) is False
     assert (
         dashboard._is_trade_closed({"status": {"tp1": "hit"}, "active": "yes"})


### PR DESCRIPTION
## Summary
- treat boolean status tokens as closed only when true so false closed flags keep trades active
- extend trade closed heuristic test coverage to ensure false closed flags remain open

## Testing
- pytest tests/test_dashboard_live_positions.py

------
https://chatgpt.com/codex/tasks/task_e_68de3640566c8321bbb98d083192a914