### PR TITLE
Fix boolean status heuristics for live trades

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -573,7 +573,12 @@ def _status_token_is_closed(value) -> bool:
     if value is None:
         return False
     if isinstance(value, bool):
-        return bool(value)
+        # Boolean flags alone do not convey whether a trade is closed.  Some backends
+        # expose ``status.open`` or ``status.active`` booleans where ``True`` means the
+        # trade is running, while others provide ``status.closed``.  The surrounding
+        # heuristics inspect the key names to interpret these values, so treat the bare
+        # boolean as "unknown" here to avoid false positives.
+        return False
     if isinstance(value, (int, float)):
         # Numerical status codes of zero commonly indicate inactivity
         return float(value) == 0.0

--- a/tests/test_dashboard_live_positions.py
+++ b/tests/test_dashboard_live_positions.py
@@ -41,6 +41,7 @@ def test_is_trade_closed_heuristics(monkeypatch):
     assert dashboard._is_trade_closed({"is_open": False}) is True
     assert dashboard._is_trade_closed({"status": {"closed": "true"}}) is True
     assert dashboard._is_trade_closed({"status": {"closed": False}}) is False
+    assert dashboard._is_trade_closed({"status": {"open": True}}) is False
     assert dashboard._is_trade_closed({"status": "open"}) is False
     assert (
         dashboard._is_trade_closed({"status": {"tp1": "hit"}, "active": "yes"})


### PR DESCRIPTION
## Summary
- avoid treating bare boolean status values as closed when normalising live position status tokens
- add a regression test covering providers that expose status.open flags

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de37b306c08321b464e458bcd1f1f8