### PR TITLE
Add diagnostics and plan for microstructure retraining

### DIFF
--- a/docs/model_retraining_plan.md
+++ b/docs/model_retraining_plan.md
@@ -1,0 +1,57 @@
+# Microstructure Feature Retraining Plan
+
+The probability model now ingests an expanded set of microstructure fields
+(order imbalance, cumulative delta, taker participation, spoofing signals,
+etc.).  To ensure the classifier learns meaningful coefficients for the new
+inputs, follow the retraining workflow below once sufficient data has been
+captured.
+
+## 1. Start Collecting Enriched Trade Logs
+
+* Ensure the live or paper trading agent is running with the latest code so
+  every completed trade writes the new microstructure metrics to
+  `trade_history.csv` via `trade_storage.log_trade_result`.
+* Monitor the log warnings emitted by `ml_model.train_model`.  The training
+  routine reports a low coverage warning when fewer than 10 % of samples have a
+  non-zero value for a given microstructure signal.  Continue operating until
+  these warnings disappear for the fields you intend to include.
+
+## 2. Build a Clean Training Dataset
+
+* Use `scripts/prepare_dataset.py` to normalise column names, coerce types and
+  generate train/validation/test splits with the enriched feature set.
+* Inspect the resulting dataset to verify that the microstructure columns are
+  populated and have sensible ranges (e.g. `order_flow_score` near ±1,
+  `spread_bps` in tens of basis points).
+
+## 3. Retrain the Classifier
+
+* Invoke `ml_model.train_model()` (or run the corresponding CLI wrapper if you
+  have one) to retrain using the new dataset.
+* The training summary now records `micro_feature_stats` which quantify the
+  non-zero coverage and standard deviation of each microstructure signal.  Keep
+  these numbers for future reference.
+* Evaluate the reported validation metrics (accuracy, ROC-AUC, Brier score).
+  Compare them against the previous production run to confirm the enriched
+  features are beneficial.
+
+## 4. Validate Before Deployment
+
+* Perform out-of-sample checks: replay a recent time window (forward testing) or
+  run a short paper-trading session to confirm the probability outputs behave as
+  expected.
+* Review feature importances in `ml_model.json` to understand which
+  microstructure signals drive decisions.  If certain features remain unused
+  (very low importance and coverage), consider pruning them or improving their
+  data quality before the next training cycle.
+
+## 5. Schedule Ongoing Refreshes
+
+* Plan for periodic retraining (e.g. monthly or after every N new trades) so
+  the classifier adapts to regime changes while continuing to leverage the
+  microstructure telemetry.
+* Archive artefacts (`ml_model.pkl`, `ml_model.json`, dataset snapshots) from
+  each training run to support regression analysis and rollbacks.
+
+Following this cadence ensures the live agent benefits from the additional
+order-flow context without regressing on model stability or calibration.

--- a/tests/test_ml_pipeline.py
+++ b/tests/test_ml_pipeline.py
@@ -36,6 +36,18 @@ def _build_trade_history(rows: int = 80) -> pd.DataFrame:
             'sma': 1.1 + (i % 4) * 0.05,
             'atr': 0.8 + (i % 4) * 0.02,
             'volume': 1_000_000 + i * 1500,
+            'order_flow_score': 0.2 * ((-1) ** i),
+            'order_flow_flag': -1 if i % 4 == 0 else 1,
+            'cvd': 0.15 * ((-1) ** i),
+            'cvd_change': 0.1 * ((-1) ** (i + 1)),
+            'taker_buy_ratio': 0.3 * ((-1) ** i),
+            'trade_imbalance': 0.25 * ((-1) ** (i + 1)),
+            'aggressive_trade_rate': 0.05 * ((-1) ** i),
+            'spoofing_intensity': 0.1 * ((-1) ** i),
+            'spoofing_alert': 1 if i % 7 == 0 else 0,
+            'volume_ratio': 0.05 * ((-1) ** i),
+            'price_change_pct': 0.02 * ((-1) ** (i + 1)),
+            'spread_bps': 12 + (i % 5),
             'llm_approval': bool(i % 3),
             'llm_confidence': 7 + (i % 2),
             'outcome': outcome,
@@ -63,11 +75,13 @@ def test_train_model_generates_metrics(tmp_path, monkeypatch):
         assert diagnostics.validation_metrics
     else:
         assert diagnostics.model_type == 'manual'
+    assert diagnostics.micro_feature_stats
     report = ml_model.load_model_report()
     if ml_model.SKLEARN_AVAILABLE:
         assert report.get('validation_metrics')
     else:
         assert report.get('model_type') == 'manual'
+    assert report.get('micro_feature_stats')
     prob = ml_model.predict_success_probability(
         score=60,
         confidence=7,
@@ -79,6 +93,25 @@ def test_train_model_generates_metrics(tmp_path, monkeypatch):
         llm_approval=True,
         llm_confidence=8,
         feature_overrides={'volatility': 0.25},
+        micro_features={
+            'order_imbalance': 4.0,
+            'order_flow_score': 0.3,
+            'order_flow_flag': 1.0,
+            'cvd': 0.1,
+            'cvd_change': -0.05,
+            'taker_buy_ratio': 0.2,
+            'trade_imbalance': -0.1,
+            'aggressive_trade_rate': 0.15,
+            'spoofing_intensity': 0.05,
+            'spoofing_alert': 0.0,
+            'volume_ratio': 0.1,
+            'price_change_pct': 0.03,
+            'spread_bps': 15.0,
+            'macro_indicator': 20.0,
+            'htf_trend': 6.0,
+            'volatility': 22.0,
+            'sent_bias': 'bullish',
+        },
     )
     assert 0.0 <= prob <= 1.0
 


### PR DESCRIPTION
## Summary
- centralize feature definitions, normalization, and coverage checks so microstructure inputs are handled consistently
- persist microstructure coverage statistics in training diagnostics/metadata and warn when the dataset is too sparse
- document the retraining workflow and extend the ML pipeline test to assert the new metadata

## Testing
- pytest tests/test_ml_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e16bc7421483219c98606528f5ae63