### PR TITLE
Add documentation for microstructure retraining plan

### DIFF
--- a/docs/microstructure_retraining_plan.md
+++ b/docs/microstructure_retraining_plan.md
@@ -1,0 +1,49 @@
+# Microstructure Feature Retraining Plan
+
+## Overview
+
+To leverage newly engineered market microstructure signals—such as order imbalance,
+volume delta, and related order-flow metrics—the classifier must be retrained.
+Adding features to the live trading pipeline without updating the model leaves the
+existing coefficients or tree structures unaware of how to use the new inputs. This
+plan outlines how to collect the required data, retrain, and validate the enhanced
+model.
+
+## Data Collection
+
+1. Begin recording the microstructure fields in live or paper trading immediately.
+2. Build a historical dataset that includes both the existing features and the new
+   microstructure signals.
+3. Ensure timestamps and symbols align with the current feature set to keep the
+   training data consistent.
+
+## Model Retraining
+
+1. Once the dataset contains a meaningful history with the added features, retrain the
+   classifier using the expanded feature matrix.
+2. Update preprocessing pipelines so the new inputs are normalized, clipped, or
+   otherwise transformed in the same way during both training and inference.
+3. Store versioned artifacts for the retrained model, preprocessing steps, and feature
+   metadata to support reproducibility.
+
+## Evaluation Strategy
+
+1. Use cross-validation or a walk-forward (forward-testing) split on the most recent
+   market periods to quantify performance changes.
+2. Track metrics such as prediction accuracy, Sharpe ratio, and profit factor to verify
+   that the microstructure features add value.
+3. Compare signal confidence before and after retraining; microstructure-aware models
+   should exhibit higher conviction when strong order-flow support aligns with other
+   indicators.
+
+## Deployment Considerations
+
+1. Roll out the retrained model to paper trading first to validate behaviour in a live
+   environment without risk.
+2. Monitor feature availability, inference latency, and prediction drift to ensure the
+   production system consumes the new inputs correctly.
+3. Promote the model to live trading once stability and performance improvements are
+   confirmed.
+
+Following this process ensures that the trading system fully exploits the predictive
+power of microstructure signals while maintaining disciplined model governance.


### PR DESCRIPTION
## Summary
- document a plan for recording new microstructure features and retraining the classifier
- outline evaluation and deployment steps to validate improvements from the additional signals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17ba7573083219bbbaecbf6219132