### PR TITLE
Implement microstructure-aware execution planning

### DIFF
--- a/microstructure.py
+++ b/microstructure.py
@@ -16,7 +16,9 @@ dict with keys ``'bids'`` and ``'asks'``, each being a list of
 
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+import math
+from statistics import median
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def compute_spread(order_book: Dict[str, List[Tuple[float, float]]]) -> float:
@@ -95,3 +97,297 @@ def is_liquid(order_book: Dict[str, List[Tuple[float, float]]], spread_threshold
     if imbalance != imbalance:
         return False
     return abs(imbalance) < imbalance_threshold and spread < spread_threshold
+
+
+def _normalise_levels(levels: List[Tuple[Any, Any]], depth: int) -> List[Tuple[float, float]]:
+    """Return cleaned order book levels limited to ``depth`` entries."""
+
+    normalised: List[Tuple[float, float]] = []
+    for raw_price, raw_qty in levels[:depth]:
+        try:
+            price = float(raw_price)
+            qty = float(raw_qty)
+        except (TypeError, ValueError):
+            continue
+        if qty <= 0:
+            continue
+        normalised.append((price, qty))
+    return normalised
+
+
+def _volume_baseline(levels: List[Tuple[float, float]]) -> float:
+    """Return a robust baseline volume using the median of level sizes."""
+
+    if not levels:
+        return 0.0
+    volumes = [qty for _, qty in levels if qty > 0]
+    if not volumes:
+        return 0.0
+    base = median(volumes)
+    if base <= 0:
+        base = sum(volumes) / len(volumes)
+    return max(base, 0.0)
+
+
+def _find_significant_level(
+    levels: List[Tuple[float, float]],
+    *,
+    side: str,
+    reference_price: Optional[float],
+    multiplier: float,
+    max_distance: float,
+) -> Optional[Dict[str, float]]:
+    """Return the closest level whose size exceeds ``multiplier`` * baseline."""
+
+    if reference_price is not None and reference_price <= 0:
+        reference_price = None
+
+    baseline = _volume_baseline(levels)
+    if baseline <= 0:
+        return None
+    threshold = baseline * multiplier
+    for price, qty in levels:
+        if qty < threshold:
+            continue
+        if reference_price is not None and reference_price > 0:
+            if side == "bid":
+                distance = (reference_price - price) / reference_price
+                if distance < 0 or distance > max_distance:
+                    continue
+            else:  # ask side
+                distance = (price - reference_price) / reference_price
+                if distance < 0 or distance > max_distance:
+                    continue
+        return {"price": price, "quantity": qty}
+    return None
+
+
+def plan_execution(
+    side: str,
+    current_price: Optional[float],
+    order_book: Dict[str, List[Tuple[float, float]]],
+    *,
+    depth: int = 10,
+    wall_multiplier: float = 3.0,
+    support_multiplier: float = 2.0,
+) -> Dict[str, Any]:
+    """Derive a microstructure-aware execution plan.
+
+    Parameters
+    ----------
+    side : str
+        ``"buy"`` or ``"sell"`` depending on the intended trade action.
+    current_price : Optional[float]
+        Reference price used to gauge proximity to large bids/asks.
+    order_book : dict
+        Snapshot containing ``bids`` and ``asks`` lists.
+    depth : int, optional
+        Number of levels to analyse on each side (default 10).
+    wall_multiplier : float, optional
+        Multiplier applied to the baseline volume to deem a level a wall.
+    support_multiplier : float, optional
+        Multiplier applied to identify supportive liquidity on the same side
+        as the intended trade.
+
+    Returns
+    -------
+    dict
+        Dictionary containing the suggested execution price, aggressiveness,
+        liquidity notes and any recommended position size adjustment.
+    """
+
+    side = (side or "").lower()
+    if side not in {"buy", "sell"}:
+        raise ValueError("side must be 'buy' or 'sell'")
+
+    bids = _normalise_levels(order_book.get("bids", []), depth)
+    asks = _normalise_levels(order_book.get("asks", []), depth)
+    best_bid = bids[0][0] if bids else None
+    best_ask = asks[0][0] if asks else None
+    reference_price = current_price
+    if reference_price is None:
+        reference_price = best_ask if side == "buy" else best_bid
+
+    notes: List[str] = []
+    size_multiplier = 1.0
+    recommended_price: Optional[float]
+    if side == "buy":
+        recommended_price = best_ask if best_ask is not None else reference_price
+        support = _find_significant_level(
+            bids,
+            side="bid",
+            reference_price=reference_price,
+            multiplier=support_multiplier,
+            max_distance=0.0015,
+        )
+        resistance = _find_significant_level(
+            asks,
+            side="ask",
+            reference_price=reference_price,
+            multiplier=wall_multiplier,
+            max_distance=0.002,
+        )
+        if support:
+            notes.append(
+                f"Support bid {support['quantity']:.2f}@{support['price']:.6f}"
+            )
+            buffer = 0.0
+            if best_ask is not None and best_bid is not None:
+                buffer = max((best_ask - best_bid) * 0.25, support["price"] * 0.0002)
+            elif reference_price is not None:
+                buffer = reference_price * 0.0002
+            candidate = support["price"] + buffer
+            if best_ask is not None:
+                candidate = min(candidate, best_ask)
+            recommended_price = max(candidate, best_bid or candidate)
+        if resistance:
+            notes.append(
+                f"Sell wall {resistance['quantity']:.2f}@{resistance['price']:.6f}"
+            )
+            buffer = 0.0
+            if best_ask is not None and best_bid is not None:
+                buffer = max((best_ask - best_bid) * 0.25, resistance["price"] * 0.0002)
+            elif reference_price is not None:
+                buffer = reference_price * 0.0002
+            candidate = resistance["price"] - buffer
+            if best_bid is not None:
+                candidate = max(candidate, best_bid)
+            if recommended_price is None:
+                recommended_price = candidate
+            else:
+                recommended_price = min(recommended_price, candidate)
+            size_multiplier = min(size_multiplier, 0.6)
+    else:  # sell
+        recommended_price = best_bid if best_bid is not None else reference_price
+        resistance = _find_significant_level(
+            asks,
+            side="ask",
+            reference_price=reference_price,
+            multiplier=wall_multiplier,
+            max_distance=0.002,
+        )
+        if resistance:
+            notes.append(
+                f"Sell wall {resistance['quantity']:.2f}@{resistance['price']:.6f}"
+            )
+            buffer = 0.0
+            if best_ask is not None and best_bid is not None:
+                buffer = max((best_ask - best_bid) * 0.25, resistance["price"] * 0.0002)
+            elif reference_price is not None:
+                buffer = reference_price * 0.0002
+            candidate = resistance["price"] - buffer
+            if best_bid is not None:
+                candidate = max(candidate, best_bid)
+            recommended_price = min(recommended_price if recommended_price is not None else candidate, candidate)
+        support = _find_significant_level(
+            bids,
+            side="bid",
+            reference_price=reference_price,
+            multiplier=support_multiplier,
+            max_distance=0.0015,
+        )
+        if support:
+            notes.append(
+                f"Bid support {support['quantity']:.2f}@{support['price']:.6f}"
+            )
+            candidate = support["price"]
+            if recommended_price is None or candidate > recommended_price:
+                recommended_price = candidate
+
+    if recommended_price is None:
+        recommended_price = reference_price
+    if best_bid is not None and recommended_price is not None:
+        recommended_price = max(recommended_price, best_bid)
+    if best_ask is not None and recommended_price is not None:
+        recommended_price = min(recommended_price, best_ask) if side == "buy" else min(recommended_price, best_ask)
+
+    imbalance = compute_order_book_imbalance(order_book, depth=depth)
+    aggressiveness = "aggressive"
+    if side == "buy" and best_ask is not None and recommended_price is not None:
+        if recommended_price <= best_bid or recommended_price < best_ask:
+            aggressiveness = "passive"
+    elif side == "sell" and best_bid is not None and recommended_price is not None:
+        if recommended_price <= best_bid:
+            aggressiveness = "aggressive"
+        else:
+            aggressiveness = "passive"
+
+    return {
+        "side": side,
+        "recommended_price": recommended_price,
+        "size_multiplier": size_multiplier,
+        "notes": notes,
+        "imbalance": imbalance,
+        "aggressiveness": aggressiveness,
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+    }
+
+
+def detect_sell_pressure(
+    order_book: Dict[str, List[Tuple[float, float]]],
+    *,
+    depth: int = 10,
+    reference_price: Optional[float] = None,
+    ratio_threshold: float = 1.6,
+    wall_multiplier: float = 3.0,
+) -> Dict[str, Any]:
+    """Detect signs of emergent sell pressure in the order book."""
+
+    bids = _normalise_levels(order_book.get("bids", []), depth)
+    asks = _normalise_levels(order_book.get("asks", []), depth)
+    bid_volume = sum(q for _, q in bids)
+    ask_volume = sum(q for _, q in asks)
+    imbalance = compute_order_book_imbalance(order_book, depth=depth)
+
+    sell_pressure = False
+    reason: Optional[str] = None
+    urgency = "medium"
+
+    if bid_volume <= 0 and ask_volume <= 0:
+        return {
+            "sell_pressure": False,
+            "reason": None,
+            "imbalance": imbalance,
+            "bid_volume": bid_volume,
+            "ask_volume": ask_volume,
+            "wall_price": None,
+            "urgency": "low",
+        }
+
+    volume_ratio = (ask_volume / bid_volume) if bid_volume > 0 else float("inf")
+    wall = _find_significant_level(
+        asks,
+        side="ask",
+        reference_price=reference_price,
+        multiplier=wall_multiplier,
+        max_distance=0.002,
+    )
+
+    if volume_ratio >= ratio_threshold:
+        sell_pressure = True
+        reason = f"Ask volume dominates bids ({volume_ratio:.2f}x)"
+        if volume_ratio >= ratio_threshold * 1.5:
+            urgency = "high"
+    if not sell_pressure and wall is not None:
+        sell_pressure = True
+        wall_price = wall["price"]
+        reason = f"Sell wall detected at {wall_price:.6f}"
+        distance = None
+        if reference_price and reference_price > 0:
+            distance = abs(wall_price - reference_price) / reference_price
+        if distance is not None and distance < 0.0008:
+            urgency = "high"
+    else:
+        wall_price = wall["price"] if wall is not None else None
+
+    return {
+        "sell_pressure": sell_pressure,
+        "reason": reason,
+        "imbalance": imbalance,
+        "bid_volume": bid_volume,
+        "ask_volume": ask_volume,
+        "wall_price": wall["price"] if wall is not None else None,
+        "urgency": urgency,
+        "volume_ratio": volume_ratio if math.isfinite(volume_ratio) else None,
+    }


### PR DESCRIPTION
## Summary
- add microstructure helpers to evaluate order book depth for execution pricing and sell-pressure detection
- use the execution plan when opening new trades to adjust entry price, size, and metadata
- monitor order book conditions during trade management to accelerate exits when sell pressure appears

## Testing
- python -m compileall microstructure.py agent.py trade_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e3b0777e0483218db6610616fc592b