### PR TITLE
Add EMA smoothing option to weight optimizer

### DIFF
--- a/tests/test_weight_optimizer.py
+++ b/tests/test_weight_optimizer.py
@@ -1,5 +1,7 @@
 import importlib
+
 import pandas as pd
+import pytest
 
 def test_optimize_indicator_weights(monkeypatch, tmp_path):
     sig_file = tmp_path / "signal_log.csv"
@@ -21,6 +23,6 @@ def test_optimize_indicator_weights(monkeypatch, tmp_path):
     importlib.reload(trade_storage)
     weight_optimizer = importlib.reload(importlib.import_module("weight_optimizer"))
     base = {"ema": 1.0, "macd": 1.0}
-    optimized = weight_optimizer.optimize_indicator_weights(base)
-    assert optimized["ema"] != base["ema"]
+    optimized = weight_optimizer.optimize_indicator_weights(base, ema_span=2)
+    assert optimized["ema"] == pytest.approx(0.667, rel=1e-3)
     assert optimized["macd"] == base["macd"]

--- a/weight_optimizer.py
+++ b/weight_optimizer.py
@@ -1,5 +1,8 @@
 import os
+from typing import Optional
+
 import pandas as pd
+
 from log_utils import setup_logger
 from trade_schema import normalise_history_columns
 from trade_storage import TRADE_HISTORY_FILE
@@ -9,17 +12,28 @@ SIGNAL_LOG_FILE = os.getenv("SIGNAL_LOG_FILE", os.path.join(_MODULE_DIR, "signal
 
 logger = setup_logger(__name__)
 
-def optimize_indicator_weights(base_weights: dict, lookback: int = 200) -> dict:
+def optimize_indicator_weights(
+    base_weights: dict, lookback: int = 200, ema_span: Optional[int] = None
+) -> dict:
     """Return adjusted indicator weights based on recent performance.
 
     Reads the signal log and completed trade log, joins them on timestamp and symbol,
     and calculates a simple win rate for each indicator. The base weight is scaled
-    by a factor between 0.5 and 1.0 depending on the win rate (0..1).
-    If insufficient data is available, the original weights are returned.
+    by a factor between 0.5 and 1.0 depending on the win rate (0..1). When
+    ``ema_span`` is provided the win rate uses an exponentially weighted mean so
+    that more recent trades have a larger impact while still considering a deeper
+    history. If insufficient data is available, the original weights are returned.
     """
     if not (os.path.exists(SIGNAL_LOG_FILE) and os.path.exists(TRADE_HISTORY_FILE)):
         return base_weights
     try:
+        if ema_span is not None and ema_span <= 0:
+            logger.warning(
+                "Invalid ema_span %s supplied to optimize_indicator_weights; ignoring.",
+                ema_span,
+            )
+            ema_span = None
+
         signals = pd.read_csv(SIGNAL_LOG_FILE).tail(lookback)
         trades = pd.read_csv(TRADE_HISTORY_FILE).tail(lookback)
         trades = normalise_history_columns(trades)
@@ -76,7 +90,13 @@ def optimize_indicator_weights(base_weights: dict, lookback: int = 200) -> dict:
             triggered = merged[merged[col] > 0]
             if triggered.empty:
                 continue
-            win_rate = (triggered["outcome"] == "win").mean()
+            outcome_score = (
+                triggered["outcome"].astype(str).str.lower() == "win"
+            ).astype(float)
+            if ema_span:
+                win_rate = outcome_score.ewm(span=ema_span, adjust=False).mean().iloc[-1]
+            else:
+                win_rate = outcome_score.mean()
             if win_rate == win_rate:  # check for NaN
                 new_weights[key] = round(base_weights[key] * (0.5 + win_rate / 2), 3)
         return new_weights


### PR DESCRIPTION
## Summary
- add an optional EMA span to the weight optimizer to smooth win-rate calculations
- handle invalid smoothing spans gracefully and document the behavior
- update the weight optimizer unit test to cover the EMA-based calculations

## Testing
- pytest tests/test_weight_optimizer.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c37db28c8321b013e02354e8d639