### PR TITLE
Enhance weight optimiser with context-aware adjustments

### DIFF
--- a/weight_optimizer.py
+++ b/weight_optimizer.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Iterable, Optional, Tuple
 
 import pandas as pd
 
@@ -12,14 +12,94 @@ SIGNAL_LOG_FILE = os.getenv("SIGNAL_LOG_FILE", os.path.join(_MODULE_DIR, "signal
 
 logger = setup_logger(__name__)
 
+
+MIN_CONTEXT_OBSERVATIONS = 5
+
+
+def _clean_categorical(series: pd.Series, *, valid: Optional[Iterable[str]] = None) -> pd.Series:
+    """Return a normalised categorical series with missing values filled."""
+
+    if series is None:
+        return pd.Series(dtype="object")
+    normalised = series.astype(str).str.strip()
+    normalised = normalised.replace({"nan": "", "NaT": "", "None": ""})
+    normalised = normalised.replace({"": "unknown"})
+    normalised = normalised.fillna("unknown")
+    normalised = normalised.str.title()
+    if valid is not None:
+        normalised = normalised.where(normalised.isin({v.title() for v in valid}), "Other")
+    return normalised
+
+
+def _derive_trade_type(df: pd.DataFrame) -> pd.Series:
+    """Derive a trade type label from available trade metadata."""
+
+    if "pattern" in df.columns:
+        base = df["pattern"].astype(str)
+    elif "strategy" in df.columns:
+        base = df["strategy"].astype(str)
+    elif "direction" in df.columns:
+        base = df["direction"].astype(str)
+    else:
+        return pd.Series(["Unknown"] * len(df), index=df.index)
+    trade_type = base.str.strip().replace({"": "unknown", "nan": "unknown"})
+    trade_type = trade_type.fillna("unknown")
+    return trade_type.str.title()
+
+
+def _volatility_regime(series: pd.Series) -> Tuple[pd.Series, Optional[pd.Series]]:
+    """Return categorical volatility regime labels and the numeric series used."""
+
+    numeric = pd.to_numeric(series, errors="coerce")
+    if numeric.empty:
+        return pd.Series(["Unknown"] * len(series), index=series.index), None
+    valid = numeric.dropna()
+    if valid.empty:
+        return pd.Series(["Unknown"] * len(series), index=series.index), numeric
+    quantiles = valid.quantile([0.25, 0.5, 0.75]).to_dict()
+    q1 = quantiles.get(0.25, valid.min())
+    q2 = quantiles.get(0.5, valid.median())
+    q3 = quantiles.get(0.75, valid.max())
+
+    def classify(value: float) -> str:
+        if pd.isna(value):
+            return "Unknown"
+        if value <= q1:
+            return "Low"
+        if value <= q2:
+            return "Moderate"
+        if value <= q3:
+            return "High"
+        return "Extreme"
+
+    regimes = numeric.map(classify)
+    return regimes, numeric
+
+
+def _win_rate_factor(scores: pd.Series, ema_span: Optional[int]) -> Optional[float]:
+    """Return the scaling factor based on the win rate within ``scores``."""
+
+    if scores.empty:
+        return None
+    if ema_span:
+        win_rate = scores.ewm(span=ema_span, adjust=False).mean().iloc[-1]
+    else:
+        win_rate = scores.mean()
+    if pd.isna(win_rate):
+        return None
+    win_rate = max(0.0, min(1.0, float(win_rate)))
+    return 0.5 + win_rate / 2
+
 def optimize_indicator_weights(
     base_weights: dict, lookback: int = 200, ema_span: Optional[int] = None
 ) -> dict:
     """Return adjusted indicator weights based on recent performance.
 
     Reads the signal log and completed trade log, joins them on timestamp and symbol,
-    and calculates a simple win rate for each indicator. The base weight is scaled
-    by a factor between 0.5 and 1.0 depending on the win rate (0..1). When
+    and calculates a context-aware win rate for each indicator. Each indicator's
+    performance is segmented by market session, volatility regime and derived trade
+    type. The base weight is scaled by a factor between 0.5 and 1.0 depending on the
+    win rate (0..1), emphasising the contexts with sufficient trade history. When
     ``ema_span`` is provided the win rate uses an exponentially weighted mean so
     that more recent trades have a larger impact while still considering a deeper
     history. If insufficient data is available, the original weights are returned.
@@ -74,14 +154,38 @@ def optimize_indicator_weights(
         if trades.empty or "outcome" not in trades.columns:
             return base_weights
 
+        context_columns = [
+            col
+            for col in ["session", "volatility", "pattern", "strategy", "direction"]
+            if col in trades.columns
+        ]
+
         merged = pd.merge(
             signals,
-            trades[["timestamp", "symbol", "outcome"]],
+            trades[["timestamp", "symbol", "outcome", *context_columns]],
             on=["timestamp", "symbol"],
             how="inner",
         )
         if merged.empty:
             return base_weights
+        merged = merged.sort_values("timestamp")
+
+        if "session" in merged.columns:
+            session_values = _clean_categorical(
+                merged["session"], valid={"Asia", "Europe", "US", "Unknown"}
+            )
+            merged["session"] = session_values
+        else:
+            merged["session"] = "Unknown"
+
+        if "volatility" in merged.columns:
+            volatility_labels, _ = _volatility_regime(merged["volatility"])
+            merged["volatility_regime"] = volatility_labels
+        else:
+            merged["volatility_regime"] = "Unknown"
+
+        merged["trade_type"] = _derive_trade_type(merged)
+        context_group_cols = ["session", "volatility_regime", "trade_type"]
         new_weights = base_weights.copy()
         for key in base_weights.keys():
             col = f"{key}_trigger"
@@ -93,12 +197,27 @@ def optimize_indicator_weights(
             outcome_score = (
                 triggered["outcome"].astype(str).str.lower() == "win"
             ).astype(float)
-            if ema_span:
-                win_rate = outcome_score.ewm(span=ema_span, adjust=False).mean().iloc[-1]
-            else:
-                win_rate = outcome_score.mean()
-            if win_rate == win_rate:  # check for NaN
-                new_weights[key] = round(base_weights[key] * (0.5 + win_rate / 2), 3)
+            factors = []
+            supports = []
+            for _, group in triggered.groupby(context_group_cols, dropna=False):
+                if len(group) < MIN_CONTEXT_OBSERVATIONS:
+                    continue
+                context_scores = outcome_score.loc[group.index]
+                factor = _win_rate_factor(context_scores, ema_span)
+                if factor is None:
+                    continue
+                factors.append(factor)
+                supports.append(len(group))
+
+            if factors:
+                total_support = sum(supports)
+                weighted_factor = sum(f * s for f, s in zip(factors, supports)) / total_support
+                new_weights[key] = round(base_weights[key] * weighted_factor, 3)
+                continue
+
+            fallback_factor = _win_rate_factor(outcome_score, ema_span)
+            if fallback_factor is not None:
+                new_weights[key] = round(base_weights[key] * fallback_factor, 3)
         return new_weights
     except Exception as exc:
         logger.exception("Failed to optimize indicator weights: %s", exc)


### PR DESCRIPTION
## Summary
- normalise session metadata, derive trade types and classify volatility regimes for trade history rows
- update the weight optimiser to segment indicator win rates by session, volatility regime and trade type before adjusting weights

## Testing
- pytest tests/test_weight_optimizer.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c5d9fe4c83219516718959d9960e