### PR TITLE
Refine technical score aggregation

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -17,6 +17,7 @@ from log_utils import setup_logger, LOG_FILE
 
 logger = setup_logger(__name__)
 
+import math
 import time
 import os
 import sys
@@ -479,11 +480,33 @@ def run_agent_loop() -> None:
                     indicators = {
                         "rsi": float(indicators_df['rsi'].iloc[-1] if 'rsi' in indicators_df else 50.0),
                         "macd": float(indicators_df['macd'].iloc[-1] if 'macd' in indicators_df else 0.0),
+                        "macd_signal": float(
+                            indicators_df['macd_signal'].iloc[-1]
+                            if 'macd_signal' in indicators_df
+                            else math.nan
+                        ),
                         "adx": float(indicators_df['adx'].iloc[-1] if 'adx' in indicators_df else 20.0),
+                        "di_plus": float(
+                            indicators_df['di_plus'].iloc[-1]
+                            if 'di_plus' in indicators_df
+                            else math.nan
+                        ),
+                        "di_minus": float(
+                            indicators_df['di_minus'].iloc[-1]
+                            if 'di_minus' in indicators_df
+                            else math.nan
+                        ),
                     }
                 except Exception:
                     indicators_df = price_data
-                    indicators = {"rsi": 50.0, "macd": 0.0, "adx": 20.0}
+                    indicators = {
+                        "rsi": 50.0,
+                        "macd": 0.0,
+                        "macd_signal": math.nan,
+                        "adx": 20.0,
+                        "di_plus": math.nan,
+                        "di_minus": math.nan,
+                    }
                 next_ret = 0.0
                 try:
                     if not os.path.exists(SEQ_PKL):

--- a/tests/test_summarise_technical_score.py
+++ b/tests/test_summarise_technical_score.py
@@ -1,0 +1,47 @@
+from trade_utils import summarise_technical_score
+
+
+def test_long_bias_rewards_alignment():
+    indicators = {
+        "rsi": 30.0,
+        "macd": 0.06,
+        "macd_signal": 0.015,
+        "adx": 38.0,
+        "di_plus": 32.0,
+        "di_minus": 18.0,
+    }
+
+    score = summarise_technical_score(indicators, "long")
+
+    assert 6.5 < score <= 10.0
+
+
+def test_short_bias_rewards_overbought():
+    indicators = {
+        "rsi": 72.0,
+        "macd": -0.04,
+        "macd_signal": -0.01,
+        "adx": 28.0,
+        "di_plus": 15.0,
+        "di_minus": 30.0,
+    }
+
+    score = summarise_technical_score(indicators, "short")
+
+    assert score > 6.0
+
+
+def test_counter_trend_high_adx_reduces_score():
+    indicators = {
+        "rsi": 48.0,
+        "macd": -0.01,
+        "macd_signal": 0.0,
+        "adx": 45.0,
+        "di_plus": 12.0,
+        "di_minus": 34.0,
+    }
+
+    score = summarise_technical_score(indicators, "long")
+
+    assert score < 5.0
+    assert 0.0 <= score <= 10.0


### PR DESCRIPTION
## Summary
- smooth the technical score by normalising RSI/MACD inputs and incorporating DI-aware ADX weighting
- expose DI+/DI- series alongside existing indicators so the quick score has the required context
- add unit tests that capture the revised scoring behaviour for long, short, and counter-trend scenarios

## Testing
- pytest tests/test_summarise_technical_score.py

------
https://chatgpt.com/codex/tasks/task_e_68e4a2eb70f88321aef375df7a7c8904