### PR TITLE
Gate breakout trades in balanced regimes

### DIFF
--- a/auction_state.py
+++ b/auction_state.py
@@ -1,0 +1,89 @@
+"""Market auction state classification utilities.
+
+This module combines volatility and trend diagnostics to infer whether a
+market is currently balanced or in an out-of-balance auction.  The
+classification can help the agent decide whether to favour breakout or
+mean-reversion setups.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from volatility_regime import atr_percentile, hurst_exponent
+
+__all__ = ["get_auction_state"]
+
+
+def get_auction_state(
+    df: pd.DataFrame,
+    atr_window: int = 14,
+    atr_lookback: int = 100,
+    hurst_max_lag: int = 100,
+    atr_threshold: float = 0.6,
+    trend_hurst_threshold: float = 0.55,
+    revert_hurst_threshold: float = 0.45,
+) -> str:
+    """Classify the current auction state for a market symbol.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing at least ``high``, ``low`` and ``close``
+        columns.  The data should be ordered chronologically.
+    atr_window : int, optional
+        Lookback used when computing the Average True Range (default 14).
+    atr_lookback : int, optional
+        Number of historical ATR values used to determine the percentile
+        (default 100).
+    hurst_max_lag : int, optional
+        Maximum lag for the Hurst exponent estimate (default 100).
+    atr_threshold : float, optional
+        Percentile threshold signalling an out-of-balance volatility
+        regime (default 0.6).
+    trend_hurst_threshold : float, optional
+        Threshold above which the market is considered trending (default
+        0.55).
+    revert_hurst_threshold : float, optional
+        Threshold below which the market is considered mean-reverting
+        (default 0.45).
+
+    Returns
+    -------
+    str
+        One of ``"out_of_balance_trend"``,
+        ``"out_of_balance_revert"``, ``"balanced"``, or ``"unknown"``
+        when insufficient data prevents a reliable classification.
+
+    Raises
+    ------
+    KeyError
+        If the required OHLC columns are missing from ``df``.
+    """
+
+    required_columns = {"high", "low", "close"}
+    missing_columns = required_columns.difference(df.columns)
+    if missing_columns:
+        missing_str = ", ".join(sorted(missing_columns))
+        raise KeyError(f"DataFrame is missing required columns: {missing_str}")
+
+    atr_p = atr_percentile(
+        df["high"],
+        df["low"],
+        df["close"],
+        window=atr_window,
+        lookback=atr_lookback,
+    )
+    hurst = hurst_exponent(df["close"], max_lag=hurst_max_lag)
+
+    if math.isnan(atr_p) or math.isnan(hurst):
+        return "unknown"
+
+    if atr_p >= atr_threshold and hurst >= trend_hurst_threshold:
+        return "out_of_balance_trend"
+    if atr_p >= atr_threshold and hurst <= revert_hurst_threshold:
+        return "out_of_balance_revert"
+    return "balanced"
+

--- a/tests/test_auction_state.py
+++ b/tests/test_auction_state.py
@@ -1,0 +1,58 @@
+import math
+
+import pandas as pd
+import pytest
+
+import auction_state
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    data = {
+        "high": [101, 102, 103, 104, 105],
+        "low": [99, 100, 101, 102, 103],
+        "close": [100, 101, 102, 103, 104],
+    }
+    return pd.DataFrame(data)
+
+
+def test_get_auction_state_trend(monkeypatch, sample_df):
+    monkeypatch.setattr(auction_state, "atr_percentile", lambda *args, **kwargs: 0.8)
+    monkeypatch.setattr(auction_state, "hurst_exponent", lambda *args, **kwargs: 0.6)
+
+    state = auction_state.get_auction_state(sample_df)
+
+    assert state == "out_of_balance_trend"
+
+
+def test_get_auction_state_reversion(monkeypatch, sample_df):
+    monkeypatch.setattr(auction_state, "atr_percentile", lambda *args, **kwargs: 0.85)
+    monkeypatch.setattr(auction_state, "hurst_exponent", lambda *args, **kwargs: 0.4)
+
+    state = auction_state.get_auction_state(sample_df)
+
+    assert state == "out_of_balance_revert"
+
+
+def test_get_auction_state_balanced(monkeypatch, sample_df):
+    monkeypatch.setattr(auction_state, "atr_percentile", lambda *args, **kwargs: 0.3)
+    monkeypatch.setattr(auction_state, "hurst_exponent", lambda *args, **kwargs: 0.52)
+
+    state = auction_state.get_auction_state(sample_df)
+
+    assert state == "balanced"
+
+
+def test_get_auction_state_unknown_on_nan(monkeypatch, sample_df):
+    monkeypatch.setattr(auction_state, "atr_percentile", lambda *args, **kwargs: math.nan)
+    monkeypatch.setattr(auction_state, "hurst_exponent", lambda *args, **kwargs: 0.5)
+
+    state = auction_state.get_auction_state(sample_df)
+
+    assert state == "unknown"
+
+
+def test_get_auction_state_missing_columns(sample_df):
+    with pytest.raises(KeyError):
+        auction_state.get_auction_state(sample_df.drop(columns=["low"]))
+

--- a/tests/test_signal_logic.py
+++ b/tests/test_signal_logic.py
@@ -1,6 +1,7 @@
 import pandas as pd
-from trade_utils import evaluate_signal
+
 from brain import should_trade
+from trade_utils import evaluate_signal
 
 
 def test_evaluate_signal_missing_columns():
@@ -80,3 +81,21 @@ def test_should_trade_demands_more_in_low_vol():
         volatility=0.1,
     )
     assert result["decision"] is False
+
+
+def test_should_trade_skips_breakout_in_balanced_regime():
+    result = should_trade(
+        symbol="ETHUSDT",
+        score=6.5,
+        direction="long",
+        indicators={},
+        session="US",
+        pattern_name="flag",
+        orderflow="neutral",
+        sentiment={"bias": "neutral"},
+        macro_news={"safe": True, "reason": ""},
+        auction_state="balanced",
+        setup_type="trend",
+    )
+    assert result["decision"] is False
+    assert "balanced" in result["reason"].lower()


### PR DESCRIPTION
## Summary
- add an auction_state helper that combines ATR percentiles and the Hurst exponent to classify market balance
- cover edge cases and behaviours with dedicated unit tests
- gate breakout-style trades when the market state is balanced by propagating the auction state through the agent and brain

## Testing
- pytest tests/test_auction_state.py tests/test_signal_logic.py

------
https://chatgpt.com/codex/tasks/task_e_68e4a691e0308321a90466f191157bfd