### PR TITLE
Add auction state display and persist volume metrics

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1057,6 +1057,19 @@ def format_active_row(symbol: str, data: dict) -> dict | None:
     except Exception:
         tech_score_val = None
     exit_reason = data.get("exit_reason", "")
+
+    def _round_price_or_none(value):
+        try:
+            if value is None or value == "":
+                return None
+            return round(float(value), 4)
+        except Exception:
+            return None
+
+    lvn_entry_val = _round_price_or_none(data.get("lvn_entry_level"))
+    lvn_stop_val = _round_price_or_none(data.get("lvn_stop"))
+    poc_target_val = _round_price_or_none(data.get("poc_target"))
+    auction_state_val = str(data.get("auction_state") or "").strip()
     return {
         "Symbol": symbol,
         "Direction": direction_raw if direction_raw is not None else ("short" if is_short else "long"),
@@ -1079,6 +1092,10 @@ def format_active_row(symbol: str, data: dict) -> dict | None:
         "LLM Confidence Score": llm_conf_val,
         "Technical Indicators": tech_score_val,
         "Exit Reason": exit_reason,
+        "Auction State": auction_state_val,
+        "LVN Entry": lvn_entry_val,
+        "LVN Stop": lvn_stop_val,
+        "POC Target": poc_target_val,
     }
 
 
@@ -1230,6 +1247,9 @@ def render_live_tab() -> None:
             "TP1": _fmt_price,
             "TP2": _fmt_price,
             "TP3": _fmt_price,
+            "LVN Entry": _fmt_price,
+            "LVN Stop": _fmt_price,
+            "POC Target": _fmt_price,
             "Quantity": _fmt_quantity,
             "Position Size (USDT)": _fmt_money,
             "PnL ($)": _fmt_money,
@@ -1266,6 +1286,9 @@ def render_live_tab() -> None:
                 "TP1": trade_info.get("tp1"),
                 "TP2": trade_info.get("tp2"),
                 "TP3": trade_info.get("tp3"),
+                "LVN Entry": trade_info.get("lvn_entry_level"),
+                "LVN Stop": trade_info.get("lvn_stop"),
+                "POC Target": trade_info.get("poc_target"),
             }
             if alt is not None:
                 base = (

--- a/docs/trade_record_format.md
+++ b/docs/trade_record_format.md
@@ -63,6 +63,18 @@ Each row recorded by `trade_storage.log_trade_result` contains the following col
 | `size_tp2` | Size closed at the TP2 partial exit. |
 | `notional_tp1` | Notional value closed at the TP1 partial exit. |
 | `notional_tp2` | Notional value closed at the TP2 partial exit. |
+| `auction_state` | Auction regime classification (e.g. `balanced`, `out_of_balance_trend`). |
+| `volume_profile_leg_type` | Indicates whether the profile was derived from an impulse or reclaim leg. |
+| `volume_profile_poc` | Point of control price from the captured volume profile. |
+| `volume_profile_lvns` | JSON array of low-volume node (LVN) prices. |
+| `volume_profile_bin_width` | Price step used when constructing the histogram bins. |
+| `volume_profile_snapshot` | JSON blob containing the full volume-profile summary (POC, LVNs, histogram bins, metadata). |
+| `lvn_entry_level` | LVN level that triggered the entry (when available). |
+| `lvn_stop` | Stop level derived from the LVN structure (when available). |
+| `poc_target` | Target price derived from the POC or reclaim objective. |
+| `orderflow_state_detail` | Detailed order-flow state captured at entry. |
+| `orderflow_features` | JSON blob of the order-flow feature vector (CVD, imbalance metrics, spoofing intensity, etc.). |
+| `orderflow_snapshot` | Combined JSON snapshot mirroring the in-memory `orderflow_analysis` structure (state + features). |
 
 The Streamlit dashboard surfaces the stage-specific `size_tp*`,
 `notional_tp*` and `pnl_tp*` columns so each partial take-profit's
@@ -92,7 +104,7 @@ Partial exits are denoted with a `_partial` suffix. Manual closures may appear a
 ## Example Header
 
 ```
-trade_id,timestamp,symbol,direction,entry_time,exit_time,entry,exit,size,notional,fees,slippage,pnl,pnl_pct,outcome,outcome_desc,exit_reason,strategy,session,confidence,btc_dominance,fear_greed,sentiment_bias,sentiment_confidence,score,pattern,narrative,llm_decision,llm_approval,llm_confidence,llm_error,technical_indicator_score,volatility,htf_trend,order_imbalance,order_flow_score,order_flow_flag,order_flow_state,cvd,cvd_change,taker_buy_ratio,trade_imbalance,aggressive_trade_rate,spoofing_intensity,spoofing_alert,volume_ratio,price_change_pct,spread_bps,macro_indicator,tp1_partial,tp2_partial,pnl_tp1,pnl_tp2,size_tp1,size_tp2,notional_tp1,notional_tp2
+trade_id,timestamp,symbol,direction,entry_time,exit_time,entry,exit,size,notional,fees,slippage,pnl,pnl_pct,outcome,outcome_desc,exit_reason,strategy,session,confidence,btc_dominance,fear_greed,sentiment_bias,sentiment_confidence,score,pattern,narrative,llm_decision,llm_approval,llm_confidence,llm_error,technical_indicator_score,volatility,htf_trend,order_imbalance,order_flow_score,order_flow_flag,order_flow_state,cvd,cvd_change,taker_buy_ratio,trade_imbalance,aggressive_trade_rate,spoofing_intensity,spoofing_alert,volume_ratio,price_change_pct,spread_bps,macro_indicator,tp1_partial,tp2_partial,pnl_tp1,pnl_tp2,size_tp1,size_tp2,notional_tp1,notional_tp2,auction_state,volume_profile_leg_type,volume_profile_poc,volume_profile_lvns,volume_profile_bin_width,volume_profile_snapshot,lvn_entry_level,lvn_stop,poc_target,orderflow_state_detail,orderflow_features,orderflow_snapshot
 ```
 
 A single trade may produce multiple rows if partial take-profits occur. Rows are grouped by `trade_id` (falling back to `entry_time`, `symbol` and `strategy` when absent) and collapsed into one summary row by `_deduplicate_history`. PnL, size and notional values are summed for the whole trade, while per-stage fields such as `pnl_tp1`, `pnl_tp2`, `size_tp1`, `size_tp2`, `notional_tp1` and `notional_tp2` detail the contribution of each partial exit alongside the `tp1_partial`/`tp2_partial` flags.

--- a/trade_schema.py
+++ b/trade_schema.py
@@ -83,6 +83,18 @@ TRADE_HISTORY_COLUMNS = [
     "size_tp2",
     "notional_tp1",
     "notional_tp2",
+    "auction_state",
+    "volume_profile_leg_type",
+    "volume_profile_poc",
+    "volume_profile_lvns",
+    "volume_profile_bin_width",
+    "volume_profile_snapshot",
+    "lvn_entry_level",
+    "lvn_stop",
+    "poc_target",
+    "orderflow_state_detail",
+    "orderflow_features",
+    "orderflow_snapshot",
 ]
 
 # Mapping of normalised legacy column names to their canonical equivalents.
@@ -176,6 +188,18 @@ COLUMN_SYNONYMS: Dict[str, str] = {
     "sizetp2": "size_tp2",
     "notionaltp1": "notional_tp1",
     "notionaltp2": "notional_tp2",
+    "auctionstate": "auction_state",
+    "volumeprofilelegtype": "volume_profile_leg_type",
+    "volumeprofilepoc": "volume_profile_poc",
+    "volumeprofilelvns": "volume_profile_lvns",
+    "volumeprofilebinwidth": "volume_profile_bin_width",
+    "volumeprofilesnapshot": "volume_profile_snapshot",
+    "lvnentrylevel": "lvn_entry_level",
+    "lvnstop": "lvn_stop",
+    "poctarget": "poc_target",
+    "orderflowstatedetail": "orderflow_state_detail",
+    "orderflowfeatures": "orderflow_features",
+    "orderflowsnapshot": "orderflow_snapshot",
 }
 
 


### PR DESCRIPTION
## Summary
- expose auction state, LVN entry/stop and POC target details in the live dashboard table and chart
- persist volume-profile and order-flow metadata in the trade history schema/documentation for retrospective analysis
- upgrade trade history consolidation to backfill newly added columns when legacy logs are rewritten

## Testing
- pytest *(blocked by Binance API connectivity attempts in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c6e2461083219fe9bf0c4f8334a1