### PR TITLE
Remove FinBERT from fused sentiment stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,9 @@ Set the following environment variables as needed:
 
 ## Sentiment Fusion
 
-Headline sentiment is now computed using a three-model stack that favours the
+Headline sentiment is now computed using a two-model stack that favours the
 newer, more numerically-aware LLMs:
 
-* **FinBERT** quickly converts individual headlines into class probabilities
-  (positive/neutral/negative).  The expected value of these probabilities is
-  mapped to ``s_fb \in [-1, 1]`` with confidence ``c_fb``.
 * **FinLlama** aggregates the headlines into a discrete signal ``s_fl \in
   \{-1,0,1\}`` (bearish/neutral/bullish) with confidence ``c_fl`` and a short
   rationale.
@@ -37,14 +34,14 @@ newer, more numerically-aware LLMs:
   of macro and micro structure disclosures released after 2023, improving
   sensitivity to numbers and longer sentences.
 
-Fusion weights default to ``0.20`` (FinBERT), ``0.45`` (FinLlama) and ``0.35``
-(FinGPT), reflecting the stronger validation performance of the generative
-models.  Bias remains bullish above ``+0.15`` and bearish below ``-0.15``.  The
-helper `fused_sentiment.calibrate_fusion_weights` function can be run on a
-labelled macro-news validation set to refresh these weights as new models (e.g.
-Llama 3‑70B financial fine-tunes or Mistral-FinRL variants) become available.
-The fused sentiment and rationale bundle is still passed to the Groq LLM for
-macro context and final arbitration.
+Fusion weights default to ``0.50`` (FinLlama) and ``0.50`` (FinGPT), reflecting
+the stronger validation performance of the generative models.  Bias remains
+bullish above ``+0.15`` and bearish below ``-0.15``.  The helper
+`fused_sentiment.calibrate_fusion_weights` function can be run on a labelled
+macro-news validation set to refresh these weights as new models (e.g. Llama 3‑70B
+financial fine-tunes or Mistral-FinRL variants) become available.  The fused
+sentiment and rationale bundle is still passed to the Groq LLM for macro context
+and final arbitration.
 
 ### Persistent data
 

--- a/docs/sentiment_model_evaluation.md
+++ b/docs/sentiment_model_evaluation.md
@@ -1,17 +1,17 @@
 # Sentiment Model Evaluation Playbook
 
-The fused sentiment stack now includes FinBERT, FinLlama and FinGPT with
-weights that default to 0.20 / 0.45 / 0.35 respectively.  To keep the
-fusion aligned with the best-performing language models release-over-release,
-run the following evaluation workflow whenever a new financial LLM becomes
-available (e.g. Llama 3-70B finetunes or Mistral-FinRL updates).
+The fused sentiment stack now includes FinLlama and FinGPT with weights that
+default to 0.50 / 0.50.  To keep the fusion aligned with the best-performing
+language models release-over-release, run the following evaluation workflow
+whenever a new financial LLM becomes available (e.g. Llama 3-70B finetunes or
+Mistral-FinRL updates).
 
 ## 1. Build a validation set
 
 * Collect at least 200 dated macro and micro news snippets with ground truth
   sentiment scores in ``[-1, 1]``.  Regulatory filings, FOMC statements and
   CPI prints are particularly valuable because they stress long-form numeric
-  reasoning – a weakness for FinBERT but a strength for FinGPT.
+  reasoning – an area where FinGPT excels compared with earlier classifiers.
 * Store the dataset as JSON lines with the fields ``{"headlines": [...], "label": float}``.
 
 ## 2. Run the evaluation helper

--- a/tests/test_fused_sentiment.py
+++ b/tests/test_fused_sentiment.py
@@ -3,33 +3,29 @@ import math
 import fused_sentiment as fs
 
 
-def test_analyze_headlines_returns_three_models(monkeypatch):
-    def fake_finbert(headlines):
-        return 0.4, 0.7, [{"positive": 0.6, "negative": 0.2}]
-
+def test_analyze_headlines_returns_two_models(monkeypatch):
     def fake_finllama(headlines):
         return 1, 0.9, "Bullish"
 
     def fake_fingpt(headlines):
         return 1, 0.8, "Reinforces upside"
 
-    monkeypatch.setattr(fs, "_finbert_expectation", fake_finbert)
     monkeypatch.setattr(fs, "_finllama_sentiment", fake_finllama)
     monkeypatch.setattr(fs, "_fingpt_sentiment", fake_fingpt)
 
-    weights = {"finbert": 0.1, "finllama": 0.5, "fingpt": 0.4}
+    weights = {"finllama": 0.5, "fingpt": 0.5}
     result = fs.analyze_headlines(["headline"], fusion_weights=weights)
 
-    assert set(result.keys()) >= {"finbert", "finllama", "fingpt", "fused", "weights"}
+    assert set(result.keys()) >= {"finllama", "fingpt", "fused", "weights"}
     assert math.isclose(sum(result["weights"].values()), 1.0)
-    # FinLlama and FinGPT should dominate the fused score
-    assert result["fused"]["score"] > result["finbert"]["score"]
+    # FinLlama and FinGPT should drive the fused score
+    assert result["fused"]["score"] >= result["finllama"]["score"]
     assert result["fused"]["bias"] == "bullish"
 
 
 def test_evaluate_and_calibrate_weights(monkeypatch):
-    up_scores = {"finbert": 0.1, "finllama": 0.82, "fingpt": 0.88}
-    down_scores = {"finbert": -0.25, "finllama": -0.96, "fingpt": -0.6}
+    up_scores = {"finllama": 0.82, "fingpt": 0.88}
+    down_scores = {"finllama": -0.96, "fingpt": -0.6}
 
     def fake_analyzer(headlines, fusion_weights=None):
         mapping = {"up": up_scores, "down": down_scores}
@@ -38,7 +34,6 @@ def test_evaluate_and_calibrate_weights(monkeypatch):
         fused_score = sum(scores[name] * weights[name] for name in weights)
         bias = "bullish" if fused_score > 0 else "bearish" if fused_score < 0 else "neutral"
         return {
-            "finbert": {"score": scores["finbert"], "confidence": 0.6},
             "finllama": {"score": scores["finllama"], "confidence": 0.9},
             "fingpt": {"score": scores["fingpt"], "confidence": 0.85},
             "fused": {"score": fused_score, "bias": bias, "confidence": 0.8},
@@ -47,10 +42,7 @@ def test_evaluate_and_calibrate_weights(monkeypatch):
     validation = [(["up"], 0.9), (["down"], -0.95)]
 
     metrics = fs.evaluate_models(validation, analyzer=fake_analyzer)
-    assert metrics["finllama"]["mae"] < metrics["finbert"]["mae"]
     assert metrics["fused"]["rmse"] >= 0
 
     weights = fs.calibrate_fusion_weights(validation, analyzer=fake_analyzer, step=0.1)
-    assert weights["finllama"] > weights["finbert"]
-    assert weights["fingpt"] >= weights["finbert"]
     assert math.isclose(sum(weights.values()), 1.0)


### PR DESCRIPTION
## Summary
- drop the FinBERT dependency from the fused sentiment module and rebalance defaults to FinLlama/FinGPT at 50-50
- update helper utilities, docs, and tests to reflect the two-model configuration

## Testing
- `pytest tests/test_fused_sentiment.py`


------
https://chatgpt.com/codex/tasks/task_e_68e4e6a9affc8321acd20a8a06ac712b