### PR TITLE
Implement async news analysis and batched LLM decisions

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -14,9 +14,11 @@ function even without LLM access.
 
 from __future__ import annotations
 
+import asyncio
+from dataclasses import dataclass
 import re
 import json
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 from log_utils import setup_logger
 import logging
 import math
@@ -86,7 +88,12 @@ except Exception:
         return ""
 
 try:
-    from fetch_news import run_news_fetcher, analyze_news_with_llm  # type: ignore
+    from fetch_news import (
+        run_news_fetcher,
+        analyze_news_with_llm,
+        run_news_fetcher_async,
+        analyze_news_with_llm_async,
+    )  # type: ignore
 except Exception:
     def run_news_fetcher() -> list:  # type: ignore
         return []
@@ -94,22 +101,551 @@ except Exception:
     def analyze_news_with_llm(events: list) -> Dict[str, Any]:  # type: ignore
         return {"safe": True, "reason": ""}
 
+    async def run_news_fetcher_async(path: str = "news_events.json") -> list:  # type: ignore
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, run_news_fetcher)
+
+    async def analyze_news_with_llm_async(events: list) -> Dict[str, Any]:  # type: ignore
+        return analyze_news_with_llm(events)
+
 # Cache for BTC context awareness
 symbol_context_cache: Dict[str, Dict[str, Any]] = {}
 
 
-def summarize_recent_news() -> str:
-    """Fetch recent events and summarise them via the LLM."""
+@dataclass(slots=True)
+class PreparedTradeDecision:
+    """Container holding deterministic context before querying the LLM."""
+
+    symbol: str
+    direction: str
+    session: str
+    setup_type: Optional[str]
+    score: float
+    indicators: Dict[str, float]
+    sentiment_bias: str
+    sentiment_confidence: float
+    fear_greed: Optional[int]
+    macro_news: Dict[str, Any]
+    news_summary: str
+    orderflow: str
+    auction_state: Optional[str]
+    pattern_name: str
+    pattern_memory_context: Dict[str, Any]
+    technical_score: float
+    final_confidence: float
+    advisor_prompt: str
+
+
+async def summarize_recent_news_async() -> str:
+    """Asynchronously fetch recent events and summarise them via the LLM."""
+
     try:
+        events: list
+        try:
+            loop = asyncio.get_running_loop()
+            events = await loop.run_in_executor(
+                None,
+                _load_cached_events,
+            )
+        except Exception:
+            events = await run_news_fetcher_async()
+        analysis = await analyze_news_with_llm_async(events)
+        return str(analysis.get("reason", ""))
+    except Exception:
+        logger.debug("Async news summary failed", exc_info=True)
+        return ""
+
+
+def summarize_recent_news() -> str:
+    """Synchronous helper that wraps :func:`summarize_recent_news_async`."""
+
+    try:
+        return asyncio.run(summarize_recent_news_async())
+    except RuntimeError:
+        # Already inside an event loop (e.g. notebook). Fallback to blocking path.
         try:
             with open("news_events.json", "r") as f:
                 events = json.load(f)
         except Exception:
             events = run_news_fetcher()
         analysis = analyze_news_with_llm(events)
-        return analysis.get("reason", "")
+        return str(analysis.get("reason", ""))
     except Exception:
+        logger.debug("Synchronous news summary failed", exc_info=True)
         return ""
+
+
+def _load_cached_events(path: str = "news_events.json") -> list:
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except Exception:
+        raise
+
+
+def prepare_trade_decision(
+    *,
+    symbol: str,
+    score: float,
+    direction: Optional[str],
+    indicators: Mapping[str, float],
+    session: str,
+    pattern_name: str,
+    orderflow: str,
+    sentiment: Mapping[str, Any],
+    macro_news: Mapping[str, Any],
+    volatility: Optional[float],
+    fear_greed: Optional[int],
+    auction_state: Optional[str],
+    setup_type: Optional[str],
+    news_summary: Optional[str] = None,
+) -> Tuple[Optional[Dict[str, Any]], Optional[PreparedTradeDecision]]:
+    """Prepare deterministic trade context and LLM prompt.
+
+    Returns a tuple ``(result, prepared)`` where ``result`` is a final decision
+    dictionary if the trade is rejected before involving the LLM.  When the LLM
+    needs to be queried, ``result`` is ``None`` and ``prepared`` contains the
+    information required to finalise the decision once a response is
+    available.
+    """
+
+    initial_direction = direction or "long"
+    technical_score = summarise_technical_score(indicators, initial_direction)
+
+    try:
+        sentiment_bias = str(sentiment.get("bias", "neutral"))
+        sentiment_confidence = float(sentiment.get("score", 5.0))
+    except Exception:
+        sentiment_bias = "neutral"
+        sentiment_confidence = 5.0
+
+    try:
+        macro_safe = bool(macro_news.get("safe", True))
+    except Exception:
+        macro_safe = True
+    if not macro_safe:
+        reason = str(macro_news.get("reason", "unknown"))
+        return (
+            {
+                "decision": False,
+                "confidence": 0.0,
+                "reason": f"Macro news unsafe: {reason}",
+                "llm_decision": None,
+                "llm_approval": None,
+                "llm_confidence": None,
+                "llm_error": False,
+                "technical_indicator_score": technical_score,
+            },
+            None,
+        )
+
+    news_summary_value = news_summary if news_summary is not None else summarize_recent_news()
+
+    try:
+        pattern_lower = pattern_name.lower() if isinstance(pattern_name, str) else ""
+    except Exception:
+        pattern_lower = ""
+
+    setup_lower = (setup_type or "").lower() if isinstance(setup_type, str) else ""
+    breakout_patterns = {
+        "triangle_wedge",
+        "flag",
+        "cup_handle",
+        "double_bottom",
+    }
+    breakout_match = (
+        setup_lower in {"trend", "breakout"}
+        or pattern_lower in breakout_patterns
+        or ("breakout" in pattern_lower if pattern_lower else False)
+    )
+    if auction_state and auction_state.lower() == "balanced" and breakout_match:
+        return (
+            {
+                "decision": False,
+                "confidence": float(score),
+                "reason": "Balanced market regime – breakout setups disabled",
+                "llm_decision": None,
+                "llm_approval": None,
+                "llm_confidence": None,
+                "llm_error": False,
+                "technical_indicator_score": technical_score,
+            },
+            None,
+        )
+
+    pattern_stats = get_pattern_posterior_stats(symbol, pattern_name)
+    posterior_mean = float(pattern_stats.get("mean", 0.5))
+    posterior_variance = float(pattern_stats.get("variance", 1.0 / 12.0))
+    trade_observations = float(pattern_stats.get("trades", 0.0))
+    pattern_memory_context = {
+        "posterior_mean": round(posterior_mean, 4),
+        "posterior_variance": round(posterior_variance, 6),
+        "trades": int(trade_observations),
+        "alpha": float(pattern_stats.get("alpha", 1.0)),
+        "beta": float(pattern_stats.get("beta", 1.0)),
+    }
+
+    base_threshold = get_adaptive_conf_threshold() or 4.5
+    if sentiment_bias == "bullish":
+        score_threshold = base_threshold - 0.3
+    elif sentiment_bias == "bearish":
+        score_threshold = base_threshold + 0.3
+    else:
+        score_threshold = base_threshold
+    score_threshold = round(score_threshold, 2)
+
+    strong_patterns = {
+        "three_white_soldiers",
+        "marubozu_bullish",
+        "bullish_engulfing",
+        "piercing_line",
+        "hammer",
+        "inverted_hammer",
+        "tweezer_bottom",
+    }
+    if pattern_lower in strong_patterns:
+        score_threshold -= 0.5
+
+    try:
+        base_thr = get_adaptive_conf_threshold() or 4.5
+    except Exception:
+        base_thr = 4.5
+    if sentiment_bias in {"bullish", "neutral"} and score >= (base_thr - 0.5):
+        score_threshold -= 0.2
+
+    if trade_observations >= 5:
+        threshold_delta = 0.0
+        if posterior_mean >= 0.6:
+            threshold_delta -= min(0.4, (posterior_mean - 0.6) * 1.5)
+        elif posterior_mean <= 0.4:
+            threshold_delta += min(0.4, (0.4 - posterior_mean) * 1.5)
+
+        if posterior_variance > 0.03:
+            threshold_delta += min(0.3, (posterior_variance - 0.03) * 10.0)
+        elif posterior_variance < 0.01:
+            threshold_delta -= min(0.2, (0.01 - posterior_variance) * 15.0)
+
+        score_threshold = round(score_threshold + threshold_delta, 2)
+
+    if volatility is not None and not math.isnan(volatility):
+        if volatility < 0.2:
+            score_threshold += 0.4
+        elif volatility > 0.8:
+            score_threshold -= 0.2
+
+    if fear_greed is not None:
+        try:
+            fg_val = float(fear_greed)
+        except Exception:
+            fg_val = None
+        if fg_val is not None:
+            if fg_val < 20:
+                score_threshold += 0.8
+            elif fg_val > 80:
+                score_threshold -= 0.2
+
+    score_threshold = round(max(score_threshold, 4.0), 2)
+
+    if direction is None and score >= score_threshold and sentiment_bias != "bearish":
+        direction = "long"
+        logger.info("Fallback direction applied: long (Sentiment: %s)", sentiment_bias)
+
+    if direction != initial_direction:
+        technical_score = summarise_technical_score(indicators, direction or initial_direction)
+
+    confidence = float(score)
+
+    if sentiment_bias == "bullish":
+        confidence += 1.0
+    elif sentiment_bias == "bearish":
+        confidence -= 1.0
+    try:
+        confidence += (float(sentiment_confidence) - 5.0) * 0.3
+    except Exception:
+        pass
+
+    if (direction or "long") == "long":
+        rsi = indicators.get("rsi", 50.0)
+        macd = indicators.get("macd", 0.0)
+        adx = indicators.get("adx", 20.0)
+        if rsi > 70:
+            confidence -= 1.0
+        elif rsi < 30:
+            confidence += 1.0
+        if macd > 0:
+            confidence += 0.5
+        if adx > 25:
+            confidence += 0.5
+
+    memory_boost = recall_pattern_confidence(symbol, pattern_name)
+    confidence += memory_boost
+
+    if trade_observations >= 3:
+        confidence += (posterior_mean - 0.5) * 2.0
+        if posterior_variance < 0.02:
+            confidence += min(0.8, (0.02 - posterior_variance) * 20.0)
+        elif posterior_variance > 0.06:
+            confidence -= min(0.8, (posterior_variance - 0.06) * 12.0)
+
+    hist_result = calculate_historical_confidence(symbol, score, direction or "long", session, pattern_name)
+    try:
+        confidence += (hist_result.get("confidence", 50) - 50) / 10.0  # type: ignore[arg-type]
+    except Exception:
+        pass
+
+    if isinstance(orderflow, str):
+        flow = orderflow.lower()
+        if "buy" in flow:
+            confidence += 0.5
+        elif "sell" in flow:
+            confidence -= 0.5
+
+    symbol_context_cache[symbol] = {
+        "bias": sentiment_bias,
+        "direction": direction or initial_direction,
+        "confidence": score,
+    }
+    if symbol != "BTCUSDT" and (direction or "long") == "long":
+        btc_ctx = symbol_context_cache.get("BTCUSDT", {})
+        if (
+            btc_ctx.get("bias") == "bullish"
+            and btc_ctx.get("direction") == "long"
+            and btc_ctx.get("confidence", 0) >= 6
+        ):
+            confidence += 0.8
+
+    exp_ret = indicators.get("next_return")
+    if exp_ret is not None:
+        try:
+            confidence += max(min(float(exp_ret) * 50.0, 2.0), -2.0)
+        except Exception:
+            pass
+
+    final_confidence = round(max(0.0, min(confidence, 10.0)), 2)
+
+    trade_direction = direction or "long"
+    if trade_direction != "long":
+        return (
+            {
+                "decision": False,
+                "confidence": final_confidence,
+                "reason": "Trade direction is not long (spot-only mode)",
+                "llm_decision": None,
+                "llm_approval": None,
+                "llm_confidence": None,
+                "llm_error": False,
+                "technical_indicator_score": technical_score,
+                "pattern_memory": pattern_memory_context,
+            },
+            None,
+        )
+    if score < score_threshold:
+        return (
+            {
+                "decision": False,
+                "confidence": final_confidence,
+                "reason": f"Score {score:.2f} below threshold {score_threshold:.2f}",
+                "llm_decision": None,
+                "llm_approval": None,
+                "llm_confidence": None,
+                "llm_error": False,
+                "technical_indicator_score": technical_score,
+                "pattern_memory": pattern_memory_context,
+            },
+            None,
+        )
+    if final_confidence < 4.0:
+        return (
+            {
+                "decision": False,
+                "confidence": final_confidence,
+                "reason": "Low confidence",
+                "llm_decision": None,
+                "llm_approval": None,
+                "llm_confidence": None,
+                "llm_error": False,
+                "technical_indicator_score": technical_score,
+                "pattern_memory": pattern_memory_context,
+            },
+            None,
+        )
+
+    recent_summary = get_recent_trade_summary(symbol=symbol, pattern=pattern_name, max_entries=3)
+    advisor_prompt = (
+        "You are an experienced crypto-trading advisor. Review the following context and respond only with valid JSON.\n\n"
+        f"### Trade Metadata\n"
+        f"Symbol: {symbol}\n"
+        f"Direction: {trade_direction}\n"
+        f"Session: {session}\n"
+        f"Setup Type: {setup_type if setup_type is not None else 'N/A'}\n"
+        f"Pre-LLM Confidence: {final_confidence:.2f}/10\n"
+        f"Technical Score: {score:.2f}\n\n"
+        "### Technical Indicators\n"
+        f"RSI: {indicators.get('rsi', 0):.1f}\n"
+        f"MACD: {indicators.get('macd', 0):.4f}\n"
+        f"ADX: {indicators.get('adx', 0):.1f}\n"
+        f"Volatility (ATR percentile): {volatility if volatility is not None and not math.isnan(volatility) else 'N/A'}\n\n"
+        "### Macro Sentiment\n"
+        f"Bias: {sentiment_bias}\n"
+        f"Confidence: {sentiment_confidence}\n"
+        f"Fear & Greed Index: {fear_greed if fear_greed is not None else 'N/A'}\n"
+        f"Macro News Safe: {macro_news.get('safe', True)}\n"
+        f"Macro News Notes: {macro_news.get('reason', 'N/A')}\n"
+        f"Recent News Summary: {news_summary_value}\n\n"
+        "### Order Flow\n"
+        f"Order Flow State: {orderflow}\n"
+        f"Auction State: {auction_state if auction_state is not None else 'N/A'}\n\n"
+        "### Historical Memory\n"
+        f"Pattern: {pattern_name}\n"
+        f"Posterior Mean Win Rate: {posterior_mean:.2%}\n"
+        f"Posterior Variance: {posterior_variance:.5f}\n"
+        f"Recorded Pattern Trades: {int(trade_observations)}\n"
+        f"Historical Context Summary: {recent_summary if recent_summary else 'No recent trades available'}\n\n"
+        "Evaluate support and conflict between sections. Provide a concise rationale highlighting decisive factors.\n"
+        "Return a JSON object with exactly these keys: decision (\"Yes\" to approve the long trade, \"No\" to reject), confidence (0-10 float), reason (<=200 characters), thesis (2-3 sentences summarizing the trade idea).\n"
+        "Do not include any additional commentary outside the JSON.\n\n"
+        "Example Approval:\n"
+        "{\n"
+        "  \"decision\": \"Yes\",\n"
+        "  \"confidence\": 7.8,\n"
+        "  \"reason\": \"Order flow aligns with bullish macro backdrop.\",\n"
+        "  \"thesis\": \"Buyers dominate while macro data turns positive; expect continuation higher.\"\n"
+        "}\n"
+        "Example Rejection:\n"
+        "{\n"
+        "  \"decision\": \"No\",\n"
+        "  \"confidence\": 3.2,\n"
+        "  \"reason\": \"Momentum and order flow diverge from bullish case.\",\n"
+        "  \"thesis\": \"Technical momentum is fading and sellers control order flow, increasing downside risk.\"\n"
+        "}\n"
+    )
+
+    prepared = PreparedTradeDecision(
+        symbol=symbol,
+        direction=trade_direction,
+        session=session,
+        setup_type=setup_type,
+        score=score,
+        indicators=dict(indicators),
+        sentiment_bias=sentiment_bias,
+        sentiment_confidence=sentiment_confidence,
+        fear_greed=fear_greed,
+        macro_news=dict(macro_news),
+        news_summary=news_summary_value,
+        orderflow=orderflow,
+        auction_state=auction_state,
+        pattern_name=pattern_name,
+        pattern_memory_context=pattern_memory_context,
+        technical_score=technical_score,
+        final_confidence=final_confidence,
+        advisor_prompt=advisor_prompt,
+    )
+
+    return None, prepared
+
+
+def finalize_trade_decision(
+    prepared: PreparedTradeDecision,
+    llm_response: Any,
+) -> Dict[str, Any]:
+    """Combine LLM response with prepared context to produce final decision."""
+
+    final_confidence = prepared.final_confidence
+    technical_score = prepared.technical_score
+    pattern_memory_context = prepared.pattern_memory_context
+    news_summary = prepared.news_summary
+
+    try:
+        resp_lc = llm_response.lower() if isinstance(llm_response, str) else ""
+    except Exception:
+        resp_lc = ""
+
+    if "error" in resp_lc:
+        narrative = generate_trade_narrative(
+            symbol=prepared.symbol,
+            direction=prepared.direction,
+            score=prepared.score,
+            confidence=final_confidence,
+            indicators=prepared.indicators,
+            sentiment_bias=prepared.sentiment_bias,
+            sentiment_confidence=prepared.sentiment_confidence,
+            orderflow=prepared.orderflow,
+            pattern=prepared.pattern_name,
+            macro_reason=prepared.macro_news.get("reason", ""),
+            news_summary=news_summary,
+        ) or f"No major pattern, but macro/sentiment context favors {prepared.direction} setup."
+        return {
+            "decision": True,
+            "confidence": final_confidence,
+            "reason": "LLM unavailable or returned error; auto-approval",
+            "narrative": narrative,
+            "news_summary": news_summary,
+            "llm_decision": "LLM unavailable",
+            "llm_approval": True,
+            "llm_confidence": None,
+            "llm_error": True,
+            "technical_indicator_score": technical_score,
+            "pattern_memory": pattern_memory_context,
+        }
+
+    parsed_decision, advisor_rating, advisor_reason, advisor_thesis = _parse_llm_response(str(llm_response))
+    if parsed_decision is None:
+        match = re.search(r"(\d+(?:\.\d+)?)", str(llm_response))
+        if match:
+            try:
+                advisor_rating = float(match.group(1))
+            except Exception:
+                advisor_rating = None
+        parsed_decision = str(llm_response).strip().lower().startswith("yes")
+        advisor_reason = str(llm_response).strip()
+        advisor_thesis = ""
+
+    if advisor_rating is not None:
+        advisor_rating = max(0.0, min(float(advisor_rating), 10.0))
+        final_confidence = round((final_confidence + advisor_rating) / 2.0, 2)
+
+    if not parsed_decision:
+        return {
+            "decision": False,
+            "confidence": final_confidence,
+            "reason": f"LLM advisor vetoed trade: {advisor_reason}",
+            "narrative": advisor_thesis,
+            "news_summary": news_summary,
+            "llm_decision": advisor_reason,
+            "llm_approval": parsed_decision,
+            "llm_confidence": advisor_rating,
+            "llm_error": False,
+            "technical_indicator_score": technical_score,
+            "pattern_memory": pattern_memory_context,
+        }
+
+    narrative = advisor_thesis or generate_trade_narrative(
+        symbol=prepared.symbol,
+        direction=prepared.direction,
+        score=prepared.score,
+        confidence=final_confidence,
+        indicators=prepared.indicators,
+        sentiment_bias=prepared.sentiment_bias,
+        sentiment_confidence=prepared.sentiment_confidence,
+        orderflow=prepared.orderflow,
+        pattern=prepared.pattern_name,
+        macro_reason=prepared.macro_news.get("reason", ""),
+        news_summary=news_summary,
+    ) or f"No major pattern, but macro/sentiment context favors {prepared.direction} setup."
+
+    return {
+        "decision": True,
+        "confidence": final_confidence,
+        "reason": "All filters passed",
+        "narrative": narrative,
+        "news_summary": news_summary,
+        "llm_decision": advisor_reason or "Approved",
+        "llm_approval": True,
+        "llm_confidence": advisor_rating,
+        "llm_error": False,
+        "technical_indicator_score": technical_score,
+        "pattern_memory": pattern_memory_context,
+    }
 
 
 def _parse_llm_response(resp: str) -> Tuple[bool | None, float | None, str, str]:
@@ -136,6 +672,7 @@ def _parse_llm_response(resp: str) -> Tuple[bool | None, float | None, str, str]
         return None, None, resp, ""
 
 
+
 def should_trade(
     symbol: str,
     score: float,
@@ -150,478 +687,36 @@ def should_trade(
     fear_greed: int | None = None,
     auction_state: str | None = None,
     setup_type: str | None = None,
+    news_summary: str | None = None,
 ) -> Dict[str, Any]:
-    """Determine whether to take a trade based on quantitative metrics and LLM guidance.
+    """Determine whether to take a trade based on quantitative metrics and LLM guidance."""
 
-    Parameters
-    ----------
-    symbol : str
-        Trading symbol (e.g., ``"BTCUSDT"``).
-    score : float
-        Technical score for the trade setup.
-    direction : str or None
-        Desired trade direction (only "long" trades are allowed).
-    indicators : dict
-        Dictionary with technical indicator values such as RSI, MACD and ADX.
-    session : str
-        Market session identifier.
-    pattern_name : str
-        Name of the candlestick pattern detected.
-    orderflow : str
-        Order flow state (e.g., "buyers", "sellers" or "neutral").
-    sentiment : dict
-        Macro sentiment dictionary with ``bias`` and ``score`` keys.
-    macro_news : dict
-        Macro news analysis result with ``safe`` and ``reason`` keys.
-    volatility : float or None, optional
-        Current ATR percentile (0-1) to adjust score requirements during
-        exceptionally quiet or volatile regimes.
-    fear_greed : int or None, optional
-        Current Fear & Greed index (0-100).  Extreme fear raises the score
-        threshold while extreme greed relaxes it slightly.
-    auction_state : str or None, optional
-        Market auction state classification (e.g. ``"balanced"``) used to
-        gate breakout setups in quiet conditions.
-    setup_type : str or None, optional
-        High level setup classification (e.g. ``"trend"`` or ``"mean_reversion"``)
-        derived from the signal evaluator to identify breakout-style trades.
-
-    Returns
-    -------
-    dict
-        A dictionary with keys ``decision`` (bool), ``confidence`` (float),
-        ``reason`` (str) and optionally ``narrative`` (str).
-    """
     initial_direction = direction or "long"
     technical_score = summarise_technical_score(indicators, initial_direction)
 
     try:
-        sentiment_bias: str = sentiment.get("bias", "neutral")  # type: ignore[arg-type]
-        sentiment_confidence: float = sentiment.get("score", 5.0)  # type: ignore[arg-type]
-        # Macro news safety check
-        if not macro_news.get("safe", True):
-            return {
-                "decision": False,
-                "confidence": 0.0,
-                "reason": "Macro news unsafe: " + macro_news.get("reason", "unknown"),
-                "llm_decision": None,
-                "llm_approval": None,
-                "llm_confidence": None,
-                "llm_error": False,
-                "technical_indicator_score": technical_score,
-            }
-
-        news_summary = summarize_recent_news()
-
-        try:
-            pattern_lower = pattern_name.lower() if isinstance(pattern_name, str) else ""
-        except Exception:
-            pattern_lower = ""
-
-        setup_lower = (setup_type or "").lower() if isinstance(setup_type, str) else ""
-        breakout_patterns = {
-            "triangle_wedge",
-            "flag",
-            "cup_handle",
-            "double_bottom",
-        }
-        breakout_match = (
-            setup_lower in {"trend", "breakout"}
-            or pattern_lower in breakout_patterns
-            or ("breakout" in pattern_lower if pattern_lower else False)
-        )
-        if auction_state and auction_state.lower() == "balanced" and breakout_match:
-            return {
-                "decision": False,
-                "confidence": float(score),
-                "reason": "Balanced market regime – breakout setups disabled",
-                "llm_decision": None,
-                "llm_approval": None,
-                "llm_confidence": None,
-                "llm_error": False,
-                "technical_indicator_score": technical_score,
-            }
-
-        pattern_stats: Dict[str, float] = get_pattern_posterior_stats(symbol, pattern_name)
-        posterior_mean = float(pattern_stats.get("mean", 0.5))
-        posterior_variance = float(pattern_stats.get("variance", 1.0 / 12.0))
-        trade_observations = float(pattern_stats.get("trades", 0.0))
-        pattern_memory_context = {
-            "posterior_mean": round(posterior_mean, 4),
-            "posterior_variance": round(posterior_variance, 6),
-            "trades": int(trade_observations),
-            "alpha": float(pattern_stats.get("alpha", 1.0)),
-            "beta": float(pattern_stats.get("beta", 1.0)),
-        }
-
-        # Determine adaptive score threshold based on sentiment
-        base_threshold: float = get_adaptive_conf_threshold() or 4.5
-        if sentiment_bias == "bullish":
-            score_threshold = base_threshold - 0.3
-        elif sentiment_bias == "bearish":
-            score_threshold = base_threshold + 0.3
-        else:
-            score_threshold = base_threshold
-        score_threshold = round(score_threshold, 2)
-
-        # -----------------------------------------------------------------
-        # Quant‑style dynamic threshold adjustments
-        # Certain bullish candlestick patterns historically produce strong
-        # follow‑through.  Lower the score threshold for these patterns
-        # to ensure good setups are not discarded purely due to a high
-        # default threshold.  This is especially important when the
-        # confidence_guard module returns a strict cutoff (e.g., 5.5).
-        # We cap the minimum threshold at 4.0 to avoid approving
-        # marginal setups.
-        strong_patterns = {
-            "three_white_soldiers",
-            "marubozu_bullish",
-            "bullish_engulfing",
-            "piercing_line",
-            "hammer",
-            "inverted_hammer",
-            "tweezer_bottom",
-        }
-        if pattern_lower in strong_patterns:
-            # Reduce threshold by 0.5 for strong bullish patterns
-            score_threshold -= 0.5
-
-        # Additional adjustment: if sentiment is neutral or bullish and the
-        # raw technical score already exceeds (base_threshold - 0.5), nudge the
-        # threshold down slightly.  This encourages trades in moderately
-        # positive environments.
-        if sentiment_bias in {"bullish", "neutral"}:
-            try:
-                base_thr = get_adaptive_conf_threshold() or 4.5
-            except Exception:
-                base_thr = 4.5
-            if score >= (base_thr - 0.5):
-                score_threshold -= 0.2
-
-        # Bayesian pattern memory adjustments.  When we have sufficient
-        # observations for a given pattern-symbol combination, the posterior
-        # probability and its uncertainty modulate the score threshold.
-        if trade_observations >= 5:
-            threshold_delta = 0.0
-            if posterior_mean >= 0.6:
-                threshold_delta -= min(0.4, (posterior_mean - 0.6) * 1.5)
-            elif posterior_mean <= 0.4:
-                threshold_delta += min(0.4, (0.4 - posterior_mean) * 1.5)
-
-            if posterior_variance > 0.03:
-                threshold_delta += min(0.3, (posterior_variance - 0.03) * 10.0)
-            elif posterior_variance < 0.01:
-                threshold_delta -= min(0.2, (0.01 - posterior_variance) * 15.0)
-
-            score_threshold = round(score_threshold + threshold_delta, 2)
-
-        # Volatility-based adjustments
-        if volatility is not None and not math.isnan(volatility):
-            if volatility < 0.2:
-                score_threshold += 0.4
-            elif volatility > 0.8:
-                score_threshold -= 0.2
-
-        # Fear & Greed index adjustments
-        if fear_greed is not None:
-            try:
-                fg_val = float(fear_greed)
-            except Exception:
-                fg_val = None
-            if fg_val is not None:
-                if fg_val < 20:
-                    score_threshold += 0.8
-                elif fg_val > 80:
-                    score_threshold -= 0.2
-
-        # Ensure threshold does not fall below 4.0
-        score_threshold = round(max(score_threshold, 4.0), 2)
-
-        # Set default direction based on score and sentiment
-        if direction is None and score >= score_threshold and sentiment_bias != "bearish":
-            direction = "long"
-            logger.info("Fallback direction applied: long (Sentiment: %s)", sentiment_bias)
-
-        if direction != initial_direction:
-            technical_score = summarise_technical_score(indicators, direction)
-
-        confidence: float = float(score)
-
-        # Sentiment adjustments
-        if sentiment_bias == "bullish":
-            confidence += 1.0
-        elif sentiment_bias == "bearish":
-            confidence -= 1.0
-        try:
-            confidence += (float(sentiment_confidence) - 5.0) * 0.3
-        except Exception:
-            pass
-
-        # Indicator adjustments (RSI, MACD, ADX)
-        if direction == "long":
-            rsi = indicators.get("rsi", 50.0)
-            macd = indicators.get("macd", 0.0)
-            adx = indicators.get("adx", 20.0)
-            if rsi > 70:
-                confidence -= 1.0
-            elif rsi < 30:
-                confidence += 1.0
-            if macd > 0:
-                confidence += 0.5
-            if adx > 25:
-                confidence += 0.5
-
-        # Pattern memory boost using Bayesian posterior statistics
-        memory_boost: float = recall_pattern_confidence(symbol, pattern_name)
-        confidence += memory_boost
-
-        if trade_observations >= 3:
-            confidence += (posterior_mean - 0.5) * 2.0
-            if posterior_variance < 0.02:
-                confidence += min(0.8, (0.02 - posterior_variance) * 20.0)
-            elif posterior_variance > 0.06:
-                confidence -= min(0.8, (posterior_variance - 0.06) * 12.0)
-
-        # Historical performance boost
-        hist_result = calculate_historical_confidence(symbol, score, direction, session, pattern_name)
-        try:
-            confidence += (hist_result.get("confidence", 50) - 50) / 10.0  # type: ignore[arg-type]
-        except Exception:
-            pass
-
-        # Order flow adjustments
-        if isinstance(orderflow, str):
-            flow = orderflow.lower()
-            if "buy" in flow:
-                confidence += 0.5
-            elif "sell" in flow:
-                confidence -= 0.5
-
-        # Symbol context awareness (boost if BTC is strongly long and bullish)
-        symbol_context_cache[symbol] = {
-            "bias": sentiment_bias,
-            "direction": direction,
-            "confidence": score,
-        }
-        if symbol != "BTCUSDT" and direction == "long":
-            btc_ctx = symbol_context_cache.get("BTCUSDT", {})
-            if (
-                btc_ctx.get("bias") == "bullish"
-                and btc_ctx.get("direction") == "long"
-                and btc_ctx.get("confidence", 0) >= 6
-            ):
-                confidence += 0.8
-
-        exp_ret = indicators.get('next_return')
-        if exp_ret is not None:
-            try:
-                adj = max(min(float(exp_ret) * 50.0, 2.0), -2.0)
-                confidence += adj
-            except Exception:
-                pass
-
-        # Clamp confidence into [0, 10]
-        final_confidence = round(max(0.0, min(confidence, 10.0)), 2)
-
-        # Basic gating conditions
-        if direction != "long":
-            return {
-                "decision": False,
-                "confidence": final_confidence,
-                "reason": "Trade direction is not long (spot-only mode)",
-                "llm_decision": None,
-                "llm_approval": None,
-                "llm_confidence": None,
-                "llm_error": False,
-                "technical_indicator_score": technical_score,
-                "pattern_memory": pattern_memory_context,
-            }
-        if score < score_threshold:
-            return {
-                "decision": False,
-                "confidence": final_confidence,
-                "reason": f"Score {score:.2f} below threshold {score_threshold:.2f}",
-                "llm_decision": None,
-                "llm_approval": None,
-                "llm_confidence": None,
-                "llm_error": False,
-                "technical_indicator_score": technical_score,
-                "pattern_memory": pattern_memory_context,
-            }
-        # Require a minimum confidence but allow more flexibility for scalping.
-        # Original implementation rejected trades below 4.5; we relax this to 4.0
-        # to avoid discarding potentially profitable setups when indicators and
-        # macro conditions are supportive.
-        if final_confidence < 4.0:
-            return {
-                "decision": False,
-                "confidence": final_confidence,
-                "reason": "Low confidence",
-                "llm_decision": None,
-                "llm_approval": None,
-                "llm_confidence": None,
-                "llm_error": False,
-                "technical_indicator_score": technical_score,
-                "pattern_memory": pattern_memory_context,
-            }
-
-        advisor_rating: float | None = None
-        parsed_decision: bool | None = None
-
-        # Build prompt for LLM advisor
-        recent_summary: str = get_recent_trade_summary(symbol=symbol, pattern=pattern_name, max_entries=3)
-        advisor_prompt: str = (
-            "You are an experienced crypto-trading advisor. Review the following context and respond only with valid JSON.\n\n"
-            f"### Trade Metadata\n"
-            f"Symbol: {symbol}\n"
-            f"Direction: {direction}\n"
-            f"Session: {session}\n"
-            f"Setup Type: {setup_type if setup_type is not None else 'N/A'}\n"
-            f"Pre-LLM Confidence: {final_confidence:.2f}/10\n"
-            f"Technical Score: {score:.2f}\n\n"
-            "### Technical Indicators\n"
-            f"RSI: {indicators.get('rsi', 0):.1f}\n"
-            f"MACD: {indicators.get('macd', 0):.4f}\n"
-            f"ADX: {indicators.get('adx', 0):.1f}\n"
-            f"Volatility (ATR percentile): {volatility if volatility is not None and not math.isnan(volatility) else 'N/A'}\n\n"
-            "### Macro Sentiment\n"
-            f"Bias: {sentiment_bias}\n"
-            f"Confidence: {sentiment_confidence}\n"
-            f"Fear & Greed Index: {fear_greed if fear_greed is not None else 'N/A'}\n"
-            f"Macro News Safe: {macro_news.get('safe', True)}\n"
-            f"Macro News Notes: {macro_news.get('reason', 'N/A')}\n"
-            f"Recent News Summary: {news_summary}\n\n"
-            "### Order Flow\n"
-            f"Order Flow State: {orderflow}\n"
-            f"Auction State: {auction_state if auction_state is not None else 'N/A'}\n\n"
-            "### Historical Memory\n"
-            f"Pattern: {pattern_name}\n"
-            f"Posterior Mean Win Rate: {posterior_mean:.2%}\n"
-            f"Posterior Variance: {posterior_variance:.5f}\n"
-            f"Recorded Pattern Trades: {int(trade_observations)}\n"
-            f"Historical Context Summary: {recent_summary if recent_summary else 'No recent trades available'}\n\n"
-            "Evaluate support and conflict between sections. Provide a concise rationale highlighting decisive factors.\n"
-            "Return a JSON object with exactly these keys: decision (\"Yes\" to approve the long trade, \"No\" to reject), confidence (0-10 float), reason (<=200 characters), thesis (2-3 sentences summarizing the trade idea).\n"
-            "Do not include any additional commentary outside the JSON.\n\n"
-            "Example Approval:\n"
-            "{{\n"
-            "  \"decision\": \"Yes\",\n"
-            "  \"confidence\": 7.8,\n"
-            "  \"reason\": \"Order flow aligns with bullish macro backdrop.\",\n"
-            "  \"thesis\": \"Buyers dominate while macro data turns positive; expect continuation higher.\"\n"
-            "}}\n"
-            "Example Rejection:\n"
-            "{{\n"
-            "  \"decision\": \"No\",\n"
-            "  \"confidence\": 3.2,\n"
-            "  \"reason\": \"Momentum and order flow diverge from bullish case.\",\n"
-            "  \"thesis\": \"Technical momentum is fading and sellers control order flow, increasing downside risk.\"\n"
-            "}}\n"
-        )
-
-        # Query the LLM advisor
-        llm_response: Any = get_llm_judgment(advisor_prompt)
-
-        # -------------------------------------------------------------------
-        # Handle LLM failures: if the response contains the word "error", auto-approve
-        # The LLM can fail if API keys are missing or other issues occur.  In such
-        # cases, we skip the LLM gating and approve the trade based on quantitative
-        # metrics alone.
-        try:
-            resp_lc = llm_response.lower() if isinstance(llm_response, str) else ""
-        except Exception:
-            resp_lc = ""
-        if "error" in resp_lc:
-            narrative = generate_trade_narrative(
-                symbol=symbol,
-                direction=direction,
-                score=score,
-                confidence=final_confidence,
-                indicators=indicators,
-                sentiment_bias=sentiment_bias,
-                sentiment_confidence=sentiment_confidence,
-                orderflow=orderflow,
-                pattern=pattern_name,
-                macro_reason=macro_news.get("reason", ""),
-                news_summary=news_summary,
-            ) or f"No major pattern, but macro/sentiment context favors {direction} setup."
-            return {
-                "decision": True,
-                "confidence": final_confidence,
-                "reason": "LLM unavailable or returned error; auto-approval",
-                "narrative": narrative,
-                "news_summary": news_summary,
-                "llm_decision": "LLM unavailable",
-                "llm_approval": True,
-                "llm_confidence": None,
-                "llm_error": True,
-                "technical_indicator_score": technical_score,
-                "pattern_memory": pattern_memory_context,
-            }
-
-        # Parse the LLM response (JSON or fallback)
-        parsed_decision, advisor_rating, advisor_reason, advisor_thesis = _parse_llm_response(str(llm_response))
-        if parsed_decision is None:
-            # Fallback: use regex to extract a number and yes/no at start
-            match = re.search(r"(\d+(?:\.\d+)?)", str(llm_response))
-            if match:
-                try:
-                    advisor_rating = float(match.group(1))
-                except Exception:
-                    advisor_rating = None
-            parsed_decision = str(llm_response).strip().lower().startswith("yes")
-            advisor_reason = str(llm_response).strip()
-            advisor_thesis = ""
-
-        # Blend advisor rating into final confidence
-        if advisor_rating is not None:
-            advisor_rating = max(0.0, min(float(advisor_rating), 10.0))
-            final_confidence = round((final_confidence + advisor_rating) / 2.0, 2)
-
-        # If the LLM advises against the trade, veto it
-        if not parsed_decision:
-            return {
-                "decision": False,
-                "confidence": final_confidence,
-                "reason": f"LLM advisor vetoed trade: {advisor_reason}",
-                "narrative": advisor_thesis,
-                "news_summary": news_summary,
-                "llm_decision": advisor_reason,
-                "llm_approval": parsed_decision,
-                "llm_confidence": advisor_rating,
-                "llm_error": False,
-                "technical_indicator_score": technical_score,
-                "pattern_memory": pattern_memory_context,
-            }
-
-        # Generate narrative
-        narrative = advisor_thesis or generate_trade_narrative(
+        pre_result, prepared = prepare_trade_decision(
             symbol=symbol,
-            direction=direction,
             score=score,
-            confidence=final_confidence,
+            direction=direction,
             indicators=indicators,
-            sentiment_bias=sentiment_bias,
-            sentiment_confidence=sentiment_confidence,
+            session=session,
+            pattern_name=pattern_name,
             orderflow=orderflow,
-            pattern=pattern_name,
-            macro_reason=macro_news.get("reason", ""),
+            sentiment=sentiment,
+            macro_news=macro_news,
+            volatility=volatility,
+            fear_greed=fear_greed,
+            auction_state=auction_state,
+            setup_type=setup_type,
             news_summary=news_summary,
-        ) or f"No major pattern, but macro/sentiment context favors {direction} setup."
+        )
+        if prepared is None:
+            assert pre_result is not None
+            return pre_result
 
-        return {
-            "decision": True,
-            "confidence": final_confidence,
-            "reason": "All filters passed",
-            "narrative": narrative,
-            "news_summary": news_summary,
-            "llm_decision": advisor_reason or "Approved",
-            "llm_approval": True,
-            "llm_confidence": advisor_rating,
-            "llm_error": False,
-            "technical_indicator_score": technical_score,
-            "pattern_memory": pattern_memory_context,
-        }
+        llm_response: Any = get_llm_judgment(prepared.advisor_prompt)
+        return finalize_trade_decision(prepared, llm_response)
 
     except Exception as e:
         return {

--- a/tests/test_brain_decision_pipeline.py
+++ b/tests/test_brain_decision_pipeline.py
@@ -1,0 +1,118 @@
+import json
+
+
+def _patch_brain_defaults(monkeypatch):
+    import brain
+
+    monkeypatch.setattr(brain, "summarise_technical_score", lambda *_: 6.0, raising=False)
+    monkeypatch.setattr(brain, "get_adaptive_conf_threshold", lambda: 5.0, raising=False)
+    monkeypatch.setattr(brain, "recall_pattern_confidence", lambda *_, **__: 0.1, raising=False)
+    monkeypatch.setattr(
+        brain,
+        "get_pattern_posterior_stats",
+        lambda *_, **__: {
+            "mean": 0.55,
+            "variance": 0.02,
+            "alpha": 3.0,
+            "beta": 2.0,
+            "trades": 10,
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        brain,
+        "calculate_historical_confidence",
+        lambda *_, **__: {"confidence": 60.0},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        brain,
+        "get_recent_trade_summary",
+        lambda *_, **__: "Recent success",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        brain,
+        "generate_trade_narrative",
+        lambda **_: "Narrative from generator",
+        raising=False,
+    )
+
+
+def test_prepare_and_finalize_trade_decision(monkeypatch):
+    import brain
+
+    _patch_brain_defaults(monkeypatch)
+
+    sentiment = {"bias": "bullish", "score": 6.5}
+    macro_news = {"safe": True, "reason": "Calm conditions"}
+
+    pre_result, prepared = brain.prepare_trade_decision(
+        symbol="ETHUSDT",
+        score=7.2,
+        direction="long",
+        indicators={"rsi": 55.0, "macd": 0.4, "adx": 28.0},
+        session="US",
+        pattern_name="hammer",
+        orderflow="buyers",
+        sentiment=sentiment,
+        macro_news=macro_news,
+        volatility=0.5,
+        fear_greed=60,
+        auction_state="trending",
+        setup_type="trend",
+        news_summary="Macro looks calm",
+    )
+
+    assert pre_result is None
+    assert prepared is not None
+
+    response = json.dumps(
+        {
+            "decision": "Yes",
+            "confidence": 8.0,
+            "reason": "Momentum aligned",
+            "thesis": "Upside momentum building.",
+        }
+    )
+
+    result = brain.finalize_trade_decision(prepared, response)
+
+    assert result["decision"] is True
+    assert result["llm_approval"] is True
+    assert result["confidence"] > 0
+    assert result["narrative"]
+
+
+def test_finalize_trade_decision_handles_error(monkeypatch):
+    import brain
+
+    _patch_brain_defaults(monkeypatch)
+
+    sentiment = {"bias": "neutral", "score": 5.0}
+    macro_news = {"safe": True, "reason": "Quiet"}
+
+    _, prepared = brain.prepare_trade_decision(
+        symbol="BTCUSDT",
+        score=6.0,
+        direction="long",
+        indicators={"rsi": 52.0, "macd": 0.2, "adx": 25.0},
+        session="EU",
+        pattern_name="marubozu_bullish",
+        orderflow="buyers",
+        sentiment=sentiment,
+        macro_news=macro_news,
+        volatility=0.4,
+        fear_greed=50,
+        auction_state="trending",
+        setup_type="trend",
+        news_summary="Quiet",
+    )
+
+    assert prepared is not None
+
+    result = brain.finalize_trade_decision(prepared, "LLM error: unavailable")
+
+    assert result["decision"] is True
+    assert result["llm_error"] is True
+    assert "auto-approval" in result["reason"].lower()

--- a/tests/test_fetch_news.py
+++ b/tests/test_fetch_news.py
@@ -1,23 +1,6 @@
+import asyncio
 import json
 from datetime import datetime, timedelta
-
-
-class _DummyCompletion:
-    class _Choice:
-        class _Message:
-            def __init__(self, content: str):
-                self.content = content
-
-        def __init__(self, content: str):
-            self.message = self._Message(content)
-
-    def __init__(self, content: str):
-        self.choices = [self._Choice(content)]
-
-
-class _DummyGroq:
-    def __init__(self, api_key: str):  # pragma: no cover - trivial
-        self.api_key = api_key
 
 
 def _example_events():
@@ -31,65 +14,101 @@ def _example_events():
     ]
 
 
-def test_analyze_news_with_llm_valid_json(monkeypatch):
+def test_analyze_news_with_llm_async_valid_json(monkeypatch):
     import fetch_news
 
     monkeypatch.setattr(fetch_news, "GROQ_API_KEY", "test-key", raising=False)
-    monkeypatch.setattr(fetch_news, "Groq", _DummyGroq, raising=False)
+    monkeypatch.setattr(fetch_news.config, "get_groq_model", lambda: "test-model", raising=False)
 
-    captured = {}
+    async def fake_post(session, payload, *, model_used):
+        assert payload["model"] == "test-model"
+        assert "Assess the market impact" in payload["messages"][1]["content"]
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {"safe_decision": "no", "reason": "Volatility expected"}
+                        )
+                    }
+                }
+            ]
+        }
 
-    def fake_safe_chat_completion(client, *, model, messages, **kwargs):
-        captured["messages"] = messages
-        payload = {"safe_decision": "no", "reason": "Volatility expected"}
-        return _DummyCompletion(json.dumps(payload))
+    monkeypatch.setattr(fetch_news, "_post_groq_request", fake_post, raising=False)
 
-    monkeypatch.setattr(fetch_news, "safe_chat_completion", fake_safe_chat_completion, raising=False)
+    def fake_quantify(events):
+        return {
+            "considered_events": len(events),
+            "events_in_window": events,
+            "window_hours": 24,
+            "high_impact_events": 1,
+            "risk_score": 3.0,
+        }
 
-    result = fetch_news.analyze_news_with_llm(_example_events())
+    monkeypatch.setattr(fetch_news, "quantify_event_risk", fake_quantify, raising=False)
+
+    def fake_reconcile(decision, reason, metrics):
+        assert decision is False
+        assert reason == "Volatility expected"
+        assert metrics["high_impact_events"] == 1
+        return False, 0.6, reason
+
+    monkeypatch.setattr(
+        fetch_news, "reconcile_with_quant_filters", fake_reconcile, raising=False
+    )
+
+    result = asyncio.run(fetch_news.analyze_news_with_llm_async(_example_events()))
 
     assert result == {"safe": False, "sensitivity": 0.6, "reason": "Volatility expected"}
-    assert captured["messages"][0]["role"] == "system"
-    assert "`safe_decision`" in captured["messages"][0]["content"]
-    assert "Events:\n" in captured["messages"][1]["content"]
 
 
-def test_analyze_news_with_llm_handles_non_json(monkeypatch, caplog):
+def test_analyze_news_with_llm_async_handles_non_json(monkeypatch):
     import fetch_news
 
     monkeypatch.setattr(fetch_news, "GROQ_API_KEY", "test-key", raising=False)
-    monkeypatch.setattr(fetch_news, "Groq", _DummyGroq, raising=False)
+    monkeypatch.setattr(fetch_news.config, "get_groq_model", lambda: "test-model", raising=False)
 
-    def fake_safe_chat_completion(client, *, model, messages, **kwargs):
-        return _DummyCompletion("I cannot comply with that request.")
+    async def fake_post(session, payload, *, model_used):
+        return {
+            "choices": [
+                {"message": {"content": "I cannot comply with that request."}}
+            ]
+        }
 
-    monkeypatch.setattr(fetch_news, "safe_chat_completion", fake_safe_chat_completion, raising=False)
-    warnings: list[str] = []
+    monkeypatch.setattr(fetch_news, "_post_groq_request", fake_post, raising=False)
+    monkeypatch.setattr(
+        fetch_news,
+        "quantify_event_risk",
+        lambda events: {
+            "considered_events": len(events),
+            "events_in_window": events,
+            "window_hours": 24,
+            "high_impact_events": 0,
+            "risk_score": 0.0,
+        },
+        raising=False,
+    )
 
-    def fake_warning(message, *args, **kwargs):  # pragma: no cover - trivial formatting
-        warnings.append(message % args if args else message)
+    result = asyncio.run(fetch_news.analyze_news_with_llm_async(_example_events()))
 
-    monkeypatch.setattr(fetch_news.logger, "warning", fake_warning, raising=False)
-
-    result = fetch_news.analyze_news_with_llm(_example_events())
-
-    assert result == {"safe": True, "sensitivity": 0, "reason": "LLM non-JSON response"}
-    assert any("LLM returned non-JSON response" in message for message in warnings)
+    assert result == {
+        "safe": True,
+        "sensitivity": 0,
+        "reason": "LLM non-JSON response",
+    }
 
 
-def test_analyze_news_with_llm_overrides_inconsistent_decision(monkeypatch):
+def test_analyze_news_with_llm_sync_wrapper(monkeypatch):
     import fetch_news
 
-    monkeypatch.setattr(fetch_news, "GROQ_API_KEY", "test-key", raising=False)
-    monkeypatch.setattr(fetch_news, "Groq", _DummyGroq, raising=False)
+    async def fake_async(events, *, session=None):
+        return {"safe": False, "sensitivity": 0.2, "reason": "Test"}
 
-    def fake_safe_chat_completion(client, *, model, messages, **kwargs):
-        return _DummyCompletion(json.dumps({"safe_decision": "yes", "reason": "Looks calm"}))
-
-    monkeypatch.setattr(fetch_news, "safe_chat_completion", fake_safe_chat_completion, raising=False)
+    monkeypatch.setattr(
+        fetch_news, "analyze_news_with_llm_async", fake_async, raising=False
+    )
 
     result = fetch_news.analyze_news_with_llm(_example_events())
 
-    assert result["safe"] is False
-    assert result["sensitivity"] == 0.6
-    assert "Overriding" in result["reason"]
+    assert result == {"safe": False, "sensitivity": 0.2, "reason": "Test"}


### PR DESCRIPTION
## Summary
- add reusable async helpers for news fetching/analysis and reuse aiohttp sessions with safe synchronous fallbacks
- expose a structured prepare/finalize decision pipeline in the brain module and hook the agent into batched Groq LLM requests
- cover the async news workflow and decision pipeline with dedicated unit tests

## Testing
- pytest tests/test_fetch_news.py tests/test_brain_decision_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e4f4f85ad08321a952c0f6c21f236b