### PR TITLE
Fix Groq fallback handling for runtime errors

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -196,13 +196,8 @@ async def analyze_news_with_llm_async(
                 response = await _post_groq_request(
                     client, payload_template, model_used=payload_template["model"]
                 )
-            except RuntimeError as err:
-                raise err
             except Exception as err:
-                if (
-                    isinstance(err, Exception)
-                    and payload_template["model"] != config.DEFAULT_GROQ_MODEL
-                ):
+                if payload_template["model"] != config.DEFAULT_GROQ_MODEL:
                     logger.warning(
                         "Groq model %s unavailable (%s). Retrying with fallback model %s.",
                         payload_template["model"],


### PR DESCRIPTION
## Summary
- allow the async Groq news analysis to retry with the default model when the preferred model triggers a runtime error
- add a regression test ensuring a runtime error from the first request falls back to the default Groq model

## Testing
- pytest tests/test_fetch_news.py

------
https://chatgpt.com/codex/tasks/task_e_68e50044a5d0832186b396f3d8f34681